### PR TITLE
Link to documentation from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ Minimal, modern embedded V8 for Python.
 
 ![MiniRacer logo: a V8 with a very snakey 8](py_mini_racer.png)
 
+[Full documentation](https://bpcreech.com/PyMiniRacer/).
+
 ## Features
 
 - Latest ECMAScript support


### PR DESCRIPTION
The README doesn't yet link to the docs. I found these via the blog entry: https://bpcreech.com/post/mini-racer/