### PR TITLE
Remove not-yet-released Python async methods

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -7,6 +7,10 @@
 
 - Consequently, Control+C (`KeyboardInterrupt`) now interrupts JS execution.
 
+- Introduced `timeout_sec` parameter to `eval`, `call`, and `execute` to replace the
+    `timeout`, which unfortunately uses milliseconds (unlike the Python standard
+    library). In the future we may emit deprecation warnings for use of `timeout`.
+
 ## 0.8.1 (2024-03-23)
 
 - A series of C++ changes which should not impact the behavior of PyMiniRacer:

--- a/README.md
+++ b/README.md
@@ -70,14 +70,6 @@ supports returning composite types such as objects:
     {'foo': 1}
 ```
 
-MiniRacer supports `async` operation, offloading evaluation from the Python event loop:
-
-```python
-    >>> import asyncio
-    >>> asyncio.run(ctx.eval_async("6*7"))
-    42
-```
-
 Composite values are serialized using JSON. Use a custom JSON encoder when sending
 non-JSON encodable parameters:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,7 +101,6 @@ dependencies = [
   "coverage[toml]",
   "pytest",
   "pytest-cov",
-  "pytest-asyncio",
 ]
 
 [[tool.hatch.envs.test.matrix]]
@@ -118,7 +117,6 @@ dependencies = [
   "coverage[toml]",
   "pytest",
   "pytest-cov",
-  "pytest-asyncio",
 ]
 
 [[tool.hatch.envs.testinstalled.matrix]]


### PR DESCRIPTION
This is a partial rollback of https://github.com/bpcreech/PyMiniRacer/pull/8 which was never released.

That PR did two main things:

* Make execution within the DLL return results via callbacks to Python instead of blocking interminably, and
* Support optional Python `asyncio` mode, offloading waiting-on-the-DLL from the asyncio event loop.

On further thought, I think the latter isn't quite necessary. For now you can use `asyncio` with PyMiniRacer easily enough, using [`loop.run_in_executor()`](https://docs.python.org/3/library/asyncio-eventloop.html#asyncio.loop.run_in_executor) to offload work from the asyncio event loop as with any other long-running synchronous code. Later, I plan to add support for JS Promises, which will let you offload work even from the JS main thread by writing `async` code *on the JS side of things*. That should enable constructs like `await ctx.eval('async function foo() { ... }\nfoo();')`

At that point, I think it will be confusingly redundant to be able to use `async` Python code to call `sync` *or* `async` JS code (resulting in double-`await` constructs like `await (await ctx.eval_async(...))` in the latter case), so let's not add the ability, at least not yet. Hopefully we can stick to a simple model like "`async` Python can call `async` JS, and sync Python can call sync JS", and *avoid mixing the paradigms*.

On the other hand the first thing, returning results via callbacks, seems worth keeping because it gives the Python side more control (over cancellation, whether from KeyboardInterrupt or timeout). And it's easier to change my mind about that because it's not part of the interface.