### PR TITLE
Move and improve exception logic

### DIFF
--- a/src/v8_py_frontend/binary_value.cc
+++ b/src/v8_py_frontend/binary_value.cc
@@ -2,11 +2,16 @@
 
 #include <v8-array-buffer.h>
 #include <v8-date.h>
+#include <v8-exception.h>
 #include <v8-local-handle.h>
 #include <v8-primitive.h>
 #include <v8-value.h>
+#include <algorithm>
 #include <cstddef>
+#include <ios>
 #include <memory>
+#include <sstream>
+#include <string>
 #include "gsl_stub.h"
 
 namespace MiniRacer {
@@ -45,8 +50,8 @@ void BinaryValueFactory::Free(gsl::owner<BinaryValue*> val) {
   delete val;
 }
 
-auto BinaryValueFactory::ConvertFromV8(v8::Local<v8::Context> context,
-                                       v8::Local<v8::Value> value)
+auto BinaryValueFactory::FromValue(v8::Local<v8::Context> context,
+                                   v8::Local<v8::Value> value)
     -> BinaryValue::Ptr {
   BinaryValue::Ptr res = New();
 
@@ -126,6 +131,82 @@ auto BinaryValueFactory::ConvertFromV8(v8::Local<v8::Context> context,
   return res;
 }
 
+auto BinaryValueFactory::FromString(std::string str,
+                                    BinaryTypes type) -> BinaryValue::Ptr {
+  BinaryValue::Ptr res = New();
+  res->len = str.size();
+  res->type = type;
+  res->bytes = new char[res->len + 1];
+  std::copy(str.begin(), str.end(), res->bytes);
+  res->bytes[res->len] = '\0';
+  return res;
+}
+
 // NOLINTEND(cppcoreguidelines-pro-type-union-access)
+
+// From v8/src/d8.cc:
+auto BinaryValueFactory::FromExceptionMessage(
+    v8::Local<v8::Context> context,
+    v8::Local<v8::Message> message,
+    v8::Local<v8::Value> exception_obj,
+    BinaryTypes result_type) -> BinaryValue::Ptr {
+  std::stringstream msg;
+
+  // Converts a V8 value to a C string.
+  auto ToCString = [](const v8::String::Utf8Value& value) {
+    return (*value == nullptr) ? "<string conversion failed>" : *value;
+  };
+
+  const v8::String::Utf8Value exception(context->GetIsolate(), exception_obj);
+  const char* exception_string = ToCString(exception);
+  if (message.IsEmpty()) {
+    // V8 didn't provide any extra information about this error; just
+    // print the exception.
+    msg << exception_string << "\n";
+  } else if (message->GetScriptOrigin().Options().IsWasm()) {
+    // Print wasm-function[(function index)]:(offset): (message).
+    const int function_index = message->GetWasmFunctionIndex();
+    const int offset = message->GetStartColumn(context).FromJust();
+    msg << "wasm-function[" << function_index << "]:0x" << std::hex << offset
+        << std::dec << ": " << exception_string << "\n";
+  } else {
+    // Print (filename):(line number): (message).
+    const v8::String::Utf8Value filename(
+        context->GetIsolate(), message->GetScriptOrigin().ResourceName());
+    const char* filename_string = ToCString(filename);
+    const int linenum = message->GetLineNumber(context).FromMaybe(-1);
+    msg << filename_string << ":" << linenum << ": " << exception_string
+        << "\n";
+    v8::Local<v8::String> sourceline;
+    if (message->GetSourceLine(context).ToLocal(&sourceline)) {
+      // Print line of source code.
+      const v8::String::Utf8Value sourcelinevalue(context->GetIsolate(),
+                                                  sourceline);
+      const char* sourceline_string = ToCString(sourcelinevalue);
+      msg << sourceline_string << "\n";
+      // Print wavy underline (GetUnderline is deprecated).
+      const int start = message->GetStartColumn();
+      const int end = std::max(message->GetEndColumn(), start + 1);
+      for (int i = 0; i < start; i++) {
+        msg << " ";
+      }
+      for (int i = start; i < end; i++) {
+        msg << "^";
+      }
+      msg << "\n";
+    }
+  }
+  v8::Local<v8::Value> stack_trace_string;
+  if (v8::TryCatch::StackTrace(context, exception_obj)
+          .ToLocal(&stack_trace_string) &&
+      stack_trace_string->IsString()) {
+    const v8::String::Utf8Value stack_trace(
+        context->GetIsolate(), stack_trace_string.As<v8::String>());
+    msg << "\n";
+    msg << ToCString(stack_trace);
+    msg << "\n";
+  }
+  return FromString(msg.str(), result_type);
+}
 
 }  // namespace MiniRacer

--- a/src/v8_py_frontend/code_evaluator.h
+++ b/src/v8_py_frontend/code_evaluator.h
@@ -7,7 +7,6 @@
 #include <v8-local-handle.h>
 #include <v8-persistent-handle.h>
 #include <cstdint>
-#include <optional>
 #include <string>
 #include "binary_value.h"
 #include "isolate_memory_monitor.h"
@@ -29,11 +28,7 @@ class CodeEvaluator {
 
  private:
   auto SummarizeTryCatch(v8::Local<v8::Context>& context,
-                         const v8::TryCatch& trycatch,
-                         BinaryTypes resultType) -> BinaryValue::Ptr;
-  auto SummarizeTryCatchAfterExecution(v8::Local<v8::Context>& context,
-                                       const v8::TryCatch& trycatch)
-      -> BinaryValue::Ptr;
+                         const v8::TryCatch& trycatch) -> BinaryValue::Ptr;
 
   auto GetFunction(const std::string& code,
                    v8::Local<v8::Context>& context,
@@ -42,9 +37,6 @@ class CodeEvaluator {
                     v8::Local<v8::Context>& context) -> BinaryValue::Ptr;
   auto EvalAsScript(const std::string& code,
                     v8::Local<v8::Context>& context) -> BinaryValue::Ptr;
-
-  auto ValueToUtf8String(v8::Local<v8::Value> value)
-      -> std::optional<std::string>;
 
   v8::Isolate* isolate_;
   v8::Persistent<v8::Context>* context_;

--- a/src/v8_py_frontend/heap_reporter.cc
+++ b/src/v8_py_frontend/heap_reporter.cc
@@ -64,9 +64,10 @@ auto HeapReporter::HeapStats() -> BinaryValue::Ptr {
   v8::Local<v8::String> output;
   if (!v8::JSON::Stringify(context, stats_obj).ToLocal(&output) ||
       output.IsEmpty()) {
-    return bv_factory_->New("error stringifying heap output", type_str_utf8);
+    return bv_factory_->FromString("error stringifying heap output",
+                                   type_str_utf8);
   }
-  return bv_factory_->ConvertFromV8(context, output);
+  return bv_factory_->FromValue(context, output);
 }
 
 namespace {
@@ -94,7 +95,7 @@ auto HeapReporter::HeapSnapshot() -> BinaryValue::Ptr {
   const auto* snap = isolate_->GetHeapProfiler()->TakeHeapSnapshot();
   StringOutputStream sos;
   snap->Serialize(&sos);
-  return bv_factory_->New(sos.result(), type_str_utf8);
+  return bv_factory_->FromString(sos.result(), type_str_utf8);
 }
 
 }  // end namespace MiniRacer

--- a/src/v8_py_frontend/mini_racer.cc
+++ b/src/v8_py_frontend/mini_racer.cc
@@ -62,10 +62,10 @@ auto Context::RunTask(std::function<BinaryValue::Ptr()> func,
       },
       /*on_canceled=*/
       [callback, cb_data, this]() {
-        callback(
-            cb_data,
-            bv_factory_.New("execution terminated", type_terminated_exception)
-                .release());
+        callback(cb_data, bv_factory_
+                              .FromString("execution terminated",
+                                          type_terminated_exception)
+                              .release());
       });
 }
 


### PR DESCRIPTION
I copied in the logic from the d8 tool (part of the v8 repo), resulting in slightly better exception reports.

I also moved this into `binary_value.h` for easier reuse in future work to expose JS Promises to Python.