### PR TITLE
Add support for JS Promises

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -175,7 +175,7 @@ Before you submit a pull request, check that it meets these guidelines:
 1. The pull request should include tests.
 1. If the pull request adds functionality, the docs should be updated. Put your new
     functionality into a function with a docstring, and add the feature to the list in
-    README.rst.
+    README.md.
 1. The pull request should work for the entire test matrix of Python versions
     (`hatch run tests:run`).
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,6 +101,7 @@ dependencies = [
   "coverage[toml]",
   "pytest",
   "pytest-cov",
+  "pytest-asyncio",
 ]
 
 [[tool.hatch.envs.test.matrix]]
@@ -117,6 +118,7 @@ dependencies = [
   "coverage[toml]",
   "pytest",
   "pytest-cov",
+  "pytest-asyncio",
 ]
 
 [[tool.hatch.envs.testinstalled.matrix]]

--- a/src/py_mini_racer/__init__.py
+++ b/src/py_mini_racer/__init__.py
@@ -6,6 +6,7 @@ JSFunction = py_mini_racer.JSFunction
 JSOOMException = py_mini_racer.JSOOMException
 JSObject = py_mini_racer.JSObject
 JSParseException = py_mini_racer.JSParseException
+JSPromise = py_mini_racer.JSPromise
 JSSymbol = py_mini_racer.JSSymbol
 JSTimeoutException = py_mini_racer.JSTimeoutException
 LibAlreadyInitializedError = py_mini_racer.LibAlreadyInitializedError

--- a/src/v8_py_frontend/BUILD.gn
+++ b/src/v8_py_frontend/BUILD.gn
@@ -23,6 +23,8 @@ v8_shared_library("mini_racer") {
     "isolate_memory_monitor.cc",
     "mini_racer.h",
     "mini_racer.cc",
+    "promise_attacher.h",
+    "promise_attacher.cc",
   ]
   deps = [
     "//build/config:shared_library_deps",

--- a/src/v8_py_frontend/binary_value.h
+++ b/src/v8_py_frontend/binary_value.h
@@ -5,6 +5,7 @@
 #include <v8-context.h>
 #include <v8-local-handle.h>
 #include <v8-message.h>
+#include <v8-persistent-handle.h>
 #include <v8-value.h>
 #include <cstddef>
 #include <cstdint>
@@ -31,6 +32,7 @@ enum BinaryTypes : uint8_t {
   type_function = 100,
   type_shared_array_buffer = 101,
   type_array_buffer = 102,
+  type_promise = 103,
 
   type_execute_exception = 200,
   type_parse_exception = 201,
@@ -60,8 +62,9 @@ class BinaryValueDeleter {
  * foreign function API (e.g., Python ctypes). */
 struct BinaryValue {
   union {
-    gsl::owner<void*> ptr_val;
+    char* backing_store_ptr;
     gsl::owner<char*> bytes;
+    gsl::owner<v8::Persistent<v8::Value>*> value_ptr;
     uint64_t int_val;
     double double_val;
   };

--- a/src/v8_py_frontend/callback.h
+++ b/src/v8_py_frontend/callback.h
@@ -1,0 +1,12 @@
+#ifndef INCLUDE_MINI_RACER_CALLBACK_H
+#define INCLUDE_MINI_RACER_CALLBACK_H
+
+#include "binary_value.h"
+
+namespace MiniRacer {
+
+using Callback = void (*)(void*, BinaryValue*);
+
+}  // end namespace MiniRacer
+
+#endif  // INCLUDE_MINI_RACER_CALLBACK_H

--- a/src/v8_py_frontend/exports.cc
+++ b/src/v8_py_frontend/exports.cc
@@ -1,7 +1,10 @@
+#include <v8-persistent-handle.h>
+#include <v8-value.h>
 #include <v8-version-string.h>
 #include <cstddef>
 #include <cstdint>
 #include "binary_value.h"
+#include "callback.h"
 #include "cancelable_task_runner.h"
 #include "gsl_stub.h"
 #include "mini_racer.h"
@@ -79,6 +82,13 @@ LIB_EXPORT void mr_low_memory_notification(MiniRacer::Context* mr_context) {
 
 LIB_EXPORT auto mr_v8_version() -> char const* {
   return V8_VERSION_STRING;
+}
+
+LIB_EXPORT void mr_attach_promise_then(MiniRacer::Context* mr_context,
+                                       v8::Persistent<v8::Value>* promise,
+                                       MiniRacer::Callback callback,
+                                       void* cb_data) {
+  mr_context->AttachPromiseThen(promise, callback, cb_data);
 }
 
 // FOR DEBUGGING ONLY

--- a/src/v8_py_frontend/isolate_holder.cc
+++ b/src/v8_py_frontend/isolate_holder.cc
@@ -2,6 +2,7 @@
 
 #include <v8-array-buffer.h>
 #include <v8-isolate.h>
+#include <v8-microtask.h>
 
 namespace MiniRacer {
 
@@ -11,6 +12,11 @@ IsolateHolder::IsolateHolder()
   create_params.array_buffer_allocator = allocator_.get();
 
   isolate_ = v8::Isolate::New(create_params);
+
+  // We should set kExplicit since we're running the Microtasks checkpoint
+  // manually in isolate_manager.cc. Per
+  // https://stackoverflow.com/questions/54393127/v8-how-to-correctly-handle-microtasks
+  isolate_->SetMicrotasksPolicy(v8::MicrotasksPolicy::kExplicit);
 }
 
 IsolateHolder::~IsolateHolder() {

--- a/src/v8_py_frontend/mini_racer.cc
+++ b/src/v8_py_frontend/mini_racer.cc
@@ -7,6 +7,7 @@
 #include <string>
 #include <utility>
 #include "binary_value.h"
+#include "callback.h"
 #include "cancelable_task_runner.h"
 
 namespace MiniRacer {
@@ -46,11 +47,12 @@ Context::Context()
                       &bv_factory_,
                       &isolate_memory_monitor_),
       heap_reporter_(&bv_factory_),
+      promise_attacher_(&isolate_manager_, context_holder_.Get(), &bv_factory_),
       cancelable_task_runner_(&isolate_manager_) {}
 
 template <typename Runnable>
 auto Context::RunTask(Runnable runnable,
-                      MiniRacer::Callback callback,
+                      Callback callback,
                       void* cb_data) -> std::unique_ptr<CancelableTaskHandle> {
   return cancelable_task_runner_.Schedule(
       /*runnable=*/
@@ -69,7 +71,7 @@ auto Context::RunTask(Runnable runnable,
 }
 
 auto Context::Eval(const std::string& code,
-                   MiniRacer::Callback callback,
+                   Callback callback,
                    void* cb_data) -> std::unique_ptr<CancelableTaskHandle> {
   return RunTask(
       [code, this](v8::Isolate* isolate) {
@@ -78,7 +80,7 @@ auto Context::Eval(const std::string& code,
       callback, cb_data);
 }
 
-auto Context::HeapSnapshot(MiniRacer::Callback callback, void* cb_data)
+auto Context::HeapSnapshot(Callback callback, void* cb_data)
     -> std::unique_ptr<CancelableTaskHandle> {
   return RunTask(
       [this](v8::Isolate* isolate) {
@@ -87,7 +89,7 @@ auto Context::HeapSnapshot(MiniRacer::Callback callback, void* cb_data)
       callback, cb_data);
 }
 
-auto Context::HeapStats(MiniRacer::Callback callback, void* cb_data)
+auto Context::HeapStats(Callback callback, void* cb_data)
     -> std::unique_ptr<CancelableTaskHandle> {
   return RunTask(
       [this](v8::Isolate* isolate) {

--- a/src/v8_py_frontend/mini_racer.h
+++ b/src/v8_py_frontend/mini_racer.h
@@ -1,12 +1,15 @@
 #ifndef MINI_RACER_H
 #define MINI_RACER_H
 
+#include <v8-persistent-handle.h>
+#include <v8-value.h>
 #include <cstddef>
 #include <cstdint>
 #include <filesystem>
 #include <memory>
 #include <string>
 #include "binary_value.h"
+#include "callback.h"
 #include "cancelable_task_runner.h"
 #include "code_evaluator.h"
 #include "context_holder.h"
@@ -14,10 +17,9 @@
 #include "heap_reporter.h"
 #include "isolate_manager.h"
 #include "isolate_memory_monitor.h"
+#include "promise_attacher.h"
 
 namespace MiniRacer {
-
-using Callback = void (*)(void*, BinaryValue*);
 
 class Context {
  public:
@@ -31,20 +33,23 @@ class Context {
   void ApplyLowMemoryNotification();
 
   void FreeBinaryValue(gsl::owner<BinaryValue*> val);
-  auto HeapSnapshot(MiniRacer::Callback callback,
+  auto HeapSnapshot(Callback callback,
                     void* cb_data) -> std::unique_ptr<CancelableTaskHandle>;
-  auto HeapStats(MiniRacer::Callback callback,
+  auto HeapStats(Callback callback,
                  void* cb_data) -> std::unique_ptr<CancelableTaskHandle>;
   auto Eval(const std::string& code,
-            MiniRacer::Callback callback,
+            Callback callback,
             void* cb_data) -> std::unique_ptr<CancelableTaskHandle>;
   [[nodiscard]] auto FunctionEvalCallCount() const -> uint64_t;
   [[nodiscard]] auto FullEvalCallCount() const -> uint64_t;
+  void AttachPromiseThen(v8::Persistent<v8::Value>* promise,
+                         Callback callback,
+                         void* cb_data);
 
  private:
   template <typename Runnable>
   auto RunTask(Runnable runnable,
-               MiniRacer::Callback callback,
+               Callback callback,
                void* cb_data) -> std::unique_ptr<CancelableTaskHandle>;
 
   IsolateManager isolate_manager_;
@@ -53,6 +58,7 @@ class Context {
   ContextHolder context_holder_;
   CodeEvaluator code_evaluator_;
   HeapReporter heap_reporter_;
+  PromiseAttacher promise_attacher_;
   CancelableTaskRunner cancelable_task_runner_;
 };
 
@@ -90,6 +96,12 @@ inline auto Context::FunctionEvalCallCount() const -> uint64_t {
 
 inline auto Context::FullEvalCallCount() const -> uint64_t {
   return code_evaluator_.FullEvalCallCount();
+}
+
+inline void Context::AttachPromiseThen(v8::Persistent<v8::Value>* promise,
+                                       MiniRacer::Callback callback,
+                                       void* cb_data) {
+  promise_attacher_.AttachPromiseThen(promise, callback, cb_data);
 }
 
 }  // namespace MiniRacer

--- a/src/v8_py_frontend/promise_attacher.cc
+++ b/src/v8_py_frontend/promise_attacher.cc
@@ -1,0 +1,106 @@
+#include "promise_attacher.h"
+#include <v8-context.h>
+#include <v8-external.h>
+#include <v8-function-callback.h>
+#include <v8-function.h>
+#include <v8-local-handle.h>
+#include <v8-locker.h>
+#include <v8-message.h>
+#include <v8-microtask-queue.h>
+#include <v8-persistent-handle.h>
+#include <v8-promise.h>
+#include <memory>
+#include "binary_value.h"
+#include "callback.h"
+#include "gsl_stub.h"
+#include "isolate_manager.h"
+
+namespace MiniRacer {
+
+PromiseAttacher::PromiseAttacher(IsolateManager* isolate_manager,
+                                 v8::Persistent<v8::Context>* context,
+                                 BinaryValueFactory* bv_factory)
+    : isolate_manager_(isolate_manager),
+      context_(context),
+      bv_factory_(bv_factory) {}
+
+void PromiseAttacher::AttachPromiseThen(v8::Persistent<v8::Value>* promise_val,
+                                        Callback callback,
+                                        void* cb_data) {
+  isolate_manager_->RunAndAwait([promise_val, callback, cb_data,
+                                 this](v8::Isolate* isolate) {
+    const v8::Locker lock(isolate);
+    const v8::HandleScope scope(isolate);
+
+    const v8::Local<v8::Value> value = promise_val->Get(isolate);
+    const v8::Local<v8::Promise> promise = value.As<v8::Promise>();
+
+    // Note that completion_handler will be deleted by whichever callback is
+    // called. (If we use auto here we can't mark gsl::owner, so disable this
+    // lint check.) NOLINTNEXTLINE(hicpp-use-auto,modernize-use-auto)
+    gsl::owner<PromiseCompletionHandler*> completion_handler =
+        new PromiseCompletionHandler(bv_factory_, callback, cb_data);
+    const v8::Local<v8::External> edata =
+        v8::External::New(isolate, completion_handler);
+
+    const v8::Local<v8::Context> context = context_->Get(isolate);
+    promise
+        ->Then(context,
+               v8::Function::New(
+                   context, &PromiseCompletionHandler::OnFulfilledStatic, edata)
+                   .ToLocalChecked(),
+               v8::Function::New(
+                   context, &PromiseCompletionHandler::OnRejectedStatic, edata)
+                   .ToLocalChecked())
+        .ToLocalChecked();
+  });
+}
+
+PromiseCompletionHandler::PromiseCompletionHandler(
+    BinaryValueFactory* bv_factory,
+    Callback callback,
+    void* cb_data)
+    : bv_factory_(bv_factory), callback_(callback), cb_data_(cb_data) {}
+
+void PromiseCompletionHandler::OnFulfilledStatic(
+    const v8::FunctionCallbackInfo<v8::Value>& info) {
+  std::unique_ptr<PromiseCompletionHandler> completion_handler(
+      static_cast<PromiseCompletionHandler*>(
+          info.Data().As<v8::External>()->Value()));
+
+  completion_handler->OnFulfilled(info.GetIsolate(), info[0]);
+}
+
+void PromiseCompletionHandler::OnRejectedStatic(
+    const v8::FunctionCallbackInfo<v8::Value>& info) {
+  std::unique_ptr<PromiseCompletionHandler> completion_handler(
+      static_cast<PromiseCompletionHandler*>(
+          info.Data().As<v8::External>()->Value()));
+
+  completion_handler->OnRejected(info.GetIsolate(), info[0]);
+}
+
+void PromiseCompletionHandler::OnFulfilled(v8::Isolate* isolate,
+                                           const v8::Local<v8::Value>& value) {
+  const v8::HandleScope scope(isolate);
+  const v8::Local<v8::Context> context = isolate->GetCurrentContext();
+  const v8::Context::Scope context_scope(context);
+
+  BinaryValue::Ptr val = bv_factory_->FromValue(context, value);
+
+  callback_(cb_data_, val.release());
+}
+
+void PromiseCompletionHandler::OnRejected(v8::Isolate* isolate,
+                                          const v8::Local<v8::Value>& exc) {
+  const v8::HandleScope scope(isolate);
+  const v8::Local<v8::Context> context = isolate->GetCurrentContext();
+  const v8::Context::Scope context_scope(context);
+
+  BinaryValue::Ptr val = bv_factory_->FromExceptionMessage(
+      context, v8::Local<v8::Message>(), exc, type_execute_exception);
+
+  callback_(cb_data_, val.release());
+}
+
+}  // end namespace MiniRacer

--- a/src/v8_py_frontend/promise_attacher.h
+++ b/src/v8_py_frontend/promise_attacher.h
@@ -1,0 +1,51 @@
+#ifndef INCLUDE_MINI_RACER_PROMISE_ATTACHER_H
+#define INCLUDE_MINI_RACER_PROMISE_ATTACHER_H
+
+#include <v8-context.h>
+#include <v8-function-callback.h>
+#include <v8-isolate.h>
+#include <v8-persistent-handle.h>
+#include "binary_value.h"
+#include "callback.h"
+#include "isolate_manager.h"
+
+namespace MiniRacer {
+
+class PromiseAttacher {
+ public:
+  PromiseAttacher(IsolateManager* isolate_manager,
+                  v8::Persistent<v8::Context>* context,
+                  BinaryValueFactory* bv_factory);
+
+  void AttachPromiseThen(v8::Persistent<v8::Value>* promise_val,
+                         Callback callback,
+                         void* cb_data);
+
+ private:
+  IsolateManager* isolate_manager_;
+  v8::Persistent<v8::Context>* context_;
+  BinaryValueFactory* bv_factory_;
+};
+
+class PromiseCompletionHandler {
+ public:
+  PromiseCompletionHandler(BinaryValueFactory* bv_factory,
+                           Callback callback_,
+                           void* cb_data);
+
+  static void OnFulfilledStatic(
+      const v8::FunctionCallbackInfo<v8::Value>& info);
+  static void OnRejectedStatic(const v8::FunctionCallbackInfo<v8::Value>& info);
+
+ private:
+  void OnFulfilled(v8::Isolate* isolate, const v8::Local<v8::Value>& value);
+  void OnRejected(v8::Isolate* isolate, const v8::Local<v8::Value>& exc);
+
+  BinaryValueFactory* bv_factory_;
+  Callback callback_;
+  void* cb_data_;
+};
+
+}  // namespace MiniRacer
+
+#endif  // INCLUDE_MINI_RACER_PROMISE_ATTACHER_H

--- a/tests/test_eval.py
+++ b/tests/test_eval.py
@@ -7,6 +7,7 @@ from py_mini_racer import (
     JSEvalException,
     JSOOMException,
     JSParseException,
+    JSPromise,
     JSSymbol,
     JSTimeoutException,
     MiniRacer,
@@ -217,15 +218,17 @@ def test_max_memory_soft():
     mr.set_hard_memory_limit(100000000)
     with pytest.raises(JSOOMException) as exc_info:
         mr.eval(
-            """let s = 1000;
-            var a = new Array(s);
-            a.fill(0);
-            while(true) {
-                s *= 1.1;
-                let n = new Array(Math.floor(s));
-                n.fill(0);
-                a = a.concat(n);
-            }""",
+            """\
+let s = 1000;
+var a = new Array(s);
+a.fill(0);
+while(true) {
+    s *= 1.1;
+    let n = new Array(Math.floor(s));
+    n.fill(0);
+    a = a.concat(n);
+}
+"""
         )
 
     assert mr.was_soft_memory_limit_reached()
@@ -238,15 +241,16 @@ def test_max_memory_hard():
     mr.set_hard_memory_limit(100000000)
     with pytest.raises(JSOOMException) as exc_info:
         mr.eval(
-            """let s = 1000;
-            var a = new Array(s);
-            a.fill(0);
-            while(true) {
-                s *= 1.1;
-                let n = new Array(Math.floor(s));
-                n.fill(0);
-                a = a.concat(n);
-            }""",
+            """\
+let s = 1000;
+var a = new Array(s);
+a.fill(0);
+while(true) {
+    s *= 1.1;
+    let n = new Array(Math.floor(s));
+    n.fill(0);
+    a = a.concat(n);
+}"""
         )
 
     assert not mr.was_soft_memory_limit_reached()
@@ -261,15 +265,16 @@ def test_max_memory_hard_eval_arg():
     mr = MiniRacer()
     with pytest.raises(JSOOMException) as exc_info:
         mr.eval(
-            """let s = 1000;
-            var a = new Array(s);
-            a.fill(0);
-            while(true) {
-                s *= 1.1;
-                let n = new Array(Math.floor(s));
-                n.fill(0);
-                a = a.concat(n);
-            }""",
+            """\
+let s = 1000;
+var a = new Array(s);
+a.fill(0);
+while(true) {
+    s *= 1.1;
+    let n = new Array(Math.floor(s));
+    n.fill(0);
+    a = a.concat(n);
+}""",
             max_memory=200000000,
         )
 
@@ -293,30 +298,30 @@ def test_microtask():
     mr = MiniRacer()
     assert not mr.eval(
         """
-    let p = Promise.resolve();
+let p = Promise.resolve();
 
-    var done = false;
+var done = false;
 
-    p.then(() => {done = true});
+p.then(() => {done = true});
 
-    done
-    """
+done
+"""
     )
     assert mr.eval("done")
 
 
-def test_async():
+def test_polling():
     mr = MiniRacer()
     assert not mr.eval(
         """
-    var done = false;
-    const shared = new SharedArrayBuffer(8);
-    const view = new Int32Array(shared);
+var done = false;
+const shared = new SharedArrayBuffer(8);
+const view = new Int32Array(shared);
 
-    const p = Atomics.waitAsync(view, 0, 0, 1000); // 1 s timeout
-    p.value.then(() => { done = true; });
-    done
-    """
+const p = Atomics.waitAsync(view, 0, 0, 1000); // 1 s timeout
+p.value.then(() => { done = true; });
+done
+"""
     )
     assert not mr.eval("done")
     start = time()
@@ -325,6 +330,61 @@ def test_async():
     while time() - start < 10 and not mr.eval("done"):
         sleep(0.1)
     assert mr.eval("done")
+
+
+def test_promise_sync():
+    mr = MiniRacer()
+    promise = mr.eval(
+        """
+const shared = new SharedArrayBuffer(8);
+const view = new Int32Array(shared);
+
+const p = Atomics.waitAsync(view, 0, 0, 1000); // 1 s timeout
+p.value  // returns a promise
+"""
+    )
+    assert isinstance(promise, JSPromise)
+    start = time()
+    # Give the 1-second wait 10 seconds to finish. (Emulated aarch64 tests are
+    # surprisingly slow!)
+    val = promise.get(timeout=10)
+    assert time() - start > 0.5
+    assert val == "timed-out"
+
+
+@pytest.mark.asyncio
+async def test_promise_async():
+    mr = MiniRacer()
+    promise = mr.eval(
+        """
+const shared = new SharedArrayBuffer(8);
+const view = new Int32Array(shared);
+
+const p = Atomics.waitAsync(view, 0, 0, 1000); // 1 s timeout
+p.value  // returns a promise
+"""
+    )
+    assert isinstance(promise, JSPromise)
+    start = time()
+    val = await promise
+    assert time() - start > 0.5
+    # Give the 1-second wait 10 seconds to finish. (Emulated aarch64 tests are
+    # surprisingly slow!)
+    assert time() - start < 10
+    assert val == "timed-out"
+
+
+def test_resolved_promise_sync():
+    mr = MiniRacer()
+    val = mr.eval("Promise.resolve(6*7)").get()
+    assert val == 42
+
+
+@pytest.mark.asyncio
+async def test_resolved_promise_async():
+    mr = MiniRacer()
+    val = await mr.eval("Promise.resolve(6*7)")
+    assert val == 42
 
 
 def test_fast_call():


### PR DESCRIPTION
Works by either:

```python
assert mr.eval("Promise.resolved(42)").get() == 42  # blocks until done
```

or in an `async` function:

```python
assert await mr.eval("Promise.resolved(42)") == 42  # yields the coroutine until done
```

I didn't put an example yet in the docs (i.e., `README.md`) because, awkwardly, there's not a good and simple way to actually make a Promise worth demoing. The usual thing is `setTimeout` but we don't have a `setTimeout` yet. I'll work on that next.

In the meanwhile this could be useful for moving CPU-intensive work off the main thread.