### PR TITLE
Remove extra copying of task functors

### DIFF
--- a/src/v8_py_frontend/task_runner.cc
+++ b/src/v8_py_frontend/task_runner.cc
@@ -4,33 +4,13 @@
 #include <v8-local-handle.h>
 #include <v8-microtask-queue.h>
 #include <v8-platform.h>
-#include <functional>
-#include <memory>
 #include <thread>
-#include <utility>
 
 namespace MiniRacer {
 
 TaskRunner::TaskRunner(v8::Platform* platform, v8::Isolate* isolate)
     : platform_(platform), isolate_(isolate) {
   thread_ = std::thread(&TaskRunner::PumpMessages, this);
-}
-
-/** Just a silly way to run code on the foreground task runner thread. */
-class AdHocTask : public v8::Task {
- public:
-  explicit AdHocTask(std::function<void()> runnable)
-      : runnable_(std::move(runnable)) {}
-
-  void Run() override { runnable_(); }
-
- private:
-  std::function<void()> runnable_;
-};
-
-void TaskRunner::Run(std::function<void()> func) {
-  platform_->GetForegroundTaskRunner(isolate_)->PostTask(
-      std::make_unique<AdHocTask>(std::move(func)));
 }
 
 void TaskRunner::TerminateOngoingTask() {


### PR DESCRIPTION
In some follow-on work I noticed we were doing extra copies and [this excellent blog post](https://taylorconor.com/blog/noncopyable-lambdas/) explains why. (TL;DR: Using std::function forces the compiler to copy data to coerce the type of the lambda from an anonymous closure to a std::function.)

Ideally this PR would have unit tests, but, welp, we don't have a C++ unit test framework set up in PyMiniRacer yet, so for now it's just an untested performance optimization. In a follow-on commit it will probably become a requirement for things to compile (because copying enclosed functor params isn't always possible).