### PR TITLE
Format docs with new mdformat_mkdocs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,7 +61,7 @@ Ready to contribute? Here's how to set up `PyMiniRacer` for local development.
     the `PyMiniRacer` build uses its own compiler (!) on most systems, our pre-commit
     rules rely on the system `clang-format` and `clang-tidy`. If your versions of those
     utilities do not match the ones `PyMiniRacer` uses on GitHub Actions, you may see
-    spurious pre-commit errors. 
+    spurious pre-commit errors.
 
     If you're on a Debian-related Linux distribution using the LLVM project's standard
     apt packages, note that you will likely have to override `/usr/bin/clang-format`
@@ -175,7 +175,7 @@ Before you submit a pull request, check that it meets these guidelines:
 1. The pull request should include tests.
 1. If the pull request adds functionality, the docs should be updated. Put your new
     functionality into a function with a docstring, and add the feature to the list in
-    README.rst. 
+    README.rst.
 1. The pull request should work for the entire test matrix of Python versions
     (`hatch run tests:run`).
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -3,7 +3,7 @@
 ## 0.9.0 (2024-03-30)
 
 - Revamped JS execution model to be out-of-thread. Python/C++ interaction now happens
-    via callbacks. 
+    via callbacks.
 
 - Consequently, Control+C (`KeyboardInterrupt`) now interrupts JS execution.
 
@@ -56,7 +56,7 @@
     `EXTENSION_NAME` module variables, and `MiniRacer.v8_flags` and `MiniRacer.ext`
     class variable have all been removed.
 - Add support for the [ECMAScript internalization API](https://v8.dev/docs/i18n) and
-    thus [the ECMA `Intl` API](https://tc39.es/ecma402/) 
+    thus [the ECMA `Intl` API](https://tc39.es/ecma402/)
 - Use [fast startup snapshots](https://v8.dev/blog/custom-startup-snapshots)
 - Switch from setuptools to Hatch
 - Switch from tox to Hatch

--- a/helpers/v8_build.py
+++ b/helpers/v8_build.py
@@ -214,8 +214,9 @@ target_os_only = "True"
         else:
             target_os = ""
 
-        with open(gclient_file, 'w') as f:
-            f.write(f"""\
+        with open(gclient_file, "w") as f:
+            f.write(
+                f"""\
 solutions = [
   {{ "name"        : "v8",
     "url"         : "https://chromium.googlesource.com/v8/v8.git",
@@ -226,7 +227,8 @@ solutions = [
   }},
 ]
 {target_os}\
-""")
+"""
+            )
 
     run(
         executable,


### PR DESCRIPTION
[An out-of-band update to `mdformat_mkdocs`](https://github.com/KyleKing/mdformat-mkdocs/issues/20) has caused it to *stop* putting weird extra spaces on the end of list items.

Also, an unrelated Python formatting nit that I had force-pushed because, apparently, 🤠.