### PR TITLE
Add ability to directly call JS functions from Python

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -10,13 +10,19 @@
 
 - Added ability to directly call `JSFunction` objects from Python. E.g.,
     `mr.eval("a => a*a")(4)` parses the given number-squaring code into a function,
-    returns that function to Python, calls it with the number `4`, and recieves the
-    result of `16`.
+    returns a handle to that function to Python, calls it with the number `4`, and
+    recieves the result of `16`.
 
 - Added a `JSUndefined` Python object to model JavaScript `undefined`. This is needed to
     properly implement the above interface for reading Object and Array elements.
     *Unfortunately, this may present a breaking change for users who assume JavaScript
     `undefined` is modeled as Python `None`.*
+
+- Removed an old optimization for `eval` on simple no-argument function calls (i.e.,
+    `myfunc()`). The optimization only delivered about a 17% speedup on no-op calls (and
+    helped relatively *less* on calls which actually did work), and for the purpose of
+    optimizing repeated calls to the same function, it's now redundant with extracting
+    and calling the function from Python, e.g., `mr.eval("myfunc")()`.
 
 ## 0.10.0 (2024-03-31)
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -8,6 +8,11 @@
     including recursively (i.e., you can read Objects embedded in other objects, and
     embed your own).
 
+- Added ability to directly call `JSFunction` objects from Python. E.g.,
+    `mr.eval("a => a*a")(4)` parses the given number-squaring code into a function,
+    returns that function to Python, calls it with the number `4`, and recieves the
+    result of `16`.
+
 - Added a `JSUndefined` Python object to model JavaScript `undefined`. This is needed to
     properly implement the above interface for reading Object and Array elements.
     *Unfortunately, this may present a breaking change for users who assume JavaScript

--- a/README.md
+++ b/README.md
@@ -62,6 +62,15 @@ Variables are kept inside of a context:
     'Sqreen'
 ```
 
+You can evaluate whole scripts within JavaScript, or define and return JavaScript
+function objects and call them from Python (*new in v0.11.0*):
+
+```python
+    >>> square = ctx.eval("a => a*a")
+    >>> square(4)
+    16
+```
+
 JavaScript Objects and Arrays are modeled in Python as dictionaries and lists (or, more
 precisely,
 [`MutableMapping`](https://docs.python.org/3/library/collections.abc.html#collections.abc.MutableMapping)

--- a/src/py_mini_racer/py_mini_racer.py
+++ b/src/py_mini_racer/py_mini_racer.py
@@ -391,11 +391,6 @@ def _build_dll_handle(dll_path) -> ctypes.CDLL:
 
     handle.mr_v8_version.restype = ctypes.c_char_p
 
-    handle.mr_full_eval_call_count.argtypes = [ctypes.c_void_p]
-    handle.mr_full_eval_call_count.restype = ctypes.c_uint64
-    handle.mr_function_eval_call_count.argtypes = [ctypes.c_void_p]
-    handle.mr_function_eval_call_count.restype = ctypes.c_uint64
-
     return handle
 
 
@@ -590,7 +585,7 @@ class MiniRacer:
         # define an all-purpose callback for _SyncFuture:
         @_MR_CALLBACK
         def mr_sync_callback(future, result):
-            future: _SyncFuture = self._active_callbacks.pop(future)
+            self._active_callbacks.pop(future)
             try:
                 value = self._binary_value_ptr_to_python(result)
                 future.set_result(value)
@@ -604,7 +599,7 @@ class MiniRacer:
         # define an all-purpose callback for asyncio.Future:
         @_MR_CALLBACK
         def mr_async_callback(future, result):
-            future: Future = self._active_callbacks.pop(future)
+            self._active_callbacks.pop(future)
             loop = future.get_loop()
             try:
                 value = self._binary_value_ptr_to_python(result)
@@ -661,16 +656,9 @@ class MiniRacer:
         if isinstance(code, str):
             code = code.encode("utf-8")
 
-        def task(callback, future):
-            return self._dll.mr_eval(
-                self.ctx,
-                code,
-                len(code),
-                callback,
-                future,
-            )
-
-        with self._run_task(task) as future:
+        with self._run_mr_async_task(
+            self._dll.mr_eval, self.ctx, code, len(code)
+        ) as future:
             return future.get(timeout=timeout_sec)
 
     def execute(
@@ -797,17 +785,9 @@ class MiniRacer:
         argv_ptr = self._python_to_binary_value_ptr(argv)
         this_ptr = self._python_to_binary_value_ptr(this)
 
-        def task(callback, future):
-            return self._dll.mr_call_function(
-                self.ctx,
-                func_ptr,
-                this_ptr,
-                argv_ptr,
-                callback,
-                future,
-            )
-
-        with self._run_task(task) as future:
+        with self._run_mr_async_task(
+            self._dll.mr_call_function, self.ctx, func_ptr, this_ptr, argv_ptr
+        ) as future:
             return future.get(timeout=timeout_sec)
 
     def set_hard_memory_limit(self, limit: int) -> None:
@@ -844,14 +824,7 @@ class MiniRacer:
     def heap_stats(self) -> dict:
         """Return the V8 isolate heap statistics."""
 
-        def task(callback, future):
-            return self._dll.mr_heap_stats(
-                self.ctx,
-                callback,
-                future,
-            )
-
-        with self._run_task(task) as future:
+        with self._run_mr_async_task(self._dll.mr_heap_stats, self.ctx) as future:
             res = future.get()
 
         return self.json_impl.loads(res)
@@ -859,45 +832,28 @@ class MiniRacer:
     def heap_snapshot(self) -> dict:
         """Return a snapshot of the V8 isolate heap."""
 
-        def task(callback, future):
-            return self._dll.mr_heap_snapshot(
-                self.ctx,
-                callback,
-                future,
-            )
-
-        with self._run_task(task) as future:
+        with self._run_mr_async_task(self._dll.mr_heap_snapshot, self.ctx) as future:
             return future.get()
 
-    def _function_eval_call_count(self) -> int:
-        """Return the number of shortcut function-like evaluations done in this context.
-
-        This is exposed for testing only."""
-        return self._dll.mr_function_eval_call_count(self.ctx)
-
-    def _full_eval_call_count(self) -> int:
-        """Return the number of full script evaluations done in this context.
-
-        This is exposed for testing only."""
-        return self._dll.mr_full_eval_call_count(self.ctx)
-
-    def _make_sync_future(self):
+    def _make_sync_future(self, hold=None):
         future = _SyncFuture()
 
         # Keep track of this future until we are called back.
         # This helps ensure Python doesn't garbage collect the future before the C++
         # side of things is done with it.
-        self._active_callbacks[future] = future
+        # The items in "hold" are the things we passed into the C++ call, likewise
+        # here to avoid garbage collection until the callback completes.
+        self._active_callbacks[future] = hold
 
         return future
 
-    def _make_async_future(self):
+    def _make_async_future(self, hold=None):
         future = Future()
 
         # Keep track of this future until we are called back.
         # This helps ensure Python doesn't garbage collect the future before the C++
         # side of things is done with it.
-        self._active_callbacks[future] = future
+        self._active_callbacks[future] = hold
 
         return future
 
@@ -1057,7 +1013,7 @@ class MiniRacer:
             self._dll.mr_free_value(self.ctx, res)
 
     @contextmanager
-    def _run_task(self, task):
+    def _run_mr_async_task(self, dll_method, *args):
         """Manages those tasks which generate callbacks from the MiniRacer DLL.
 
         Several MiniRacer functions (JS evaluation and 2 heap stats calls) are
@@ -1068,10 +1024,12 @@ class MiniRacer:
         the right caller, and we manage the lifecycle of the task and task handle.
         """
 
-        future = self._make_sync_future()
+        # Stuff the args into a map along with the future, so they aren't GC'd until
+        # the task completes:
+        future = self._make_sync_future(hold=args)
 
         # Start the task:
-        task_handle = task(self._mr_sync_callback, future)
+        task_handle = dll_method(*args, self._mr_sync_callback, future)
         try:
             # Let the caller handle waiting on the result:
             yield future

--- a/src/v8_py_frontend/code_evaluator.cc
+++ b/src/v8_py_frontend/code_evaluator.cc
@@ -2,7 +2,6 @@
 
 #include <v8-context.h>
 #include <v8-exception.h>
-#include <v8-function.h>
 #include <v8-isolate.h>
 #include <v8-local-handle.h>
 #include <v8-message.h>
@@ -23,74 +22,13 @@ CodeEvaluator::CodeEvaluator(v8::Persistent<v8::Context>* context,
       bv_factory_(bv_factory),
       memory_monitor_(memory_monitor) {}
 
-auto CodeEvaluator::SummarizeTryCatch(v8::Local<v8::Context>& context,
-                                      const v8::TryCatch& trycatch)
-    -> BinaryValue::Ptr {
-  if (memory_monitor_->IsHardMemoryLimitReached()) {
-    return bv_factory_->FromString("", type_oom_exception);
-  }
+auto CodeEvaluator::Eval(v8::Isolate* isolate,
+                         const std::string& code) -> BinaryValue::Ptr {
+  const v8::Isolate::Scope isolate_scope(isolate);
+  const v8::HandleScope handle_scope(isolate);
+  const v8::Local<v8::Context> context = context_->Get(isolate);
+  const v8::Context::Scope context_scope(context);
 
-  BinaryTypes result_type = type_execute_exception;
-  if (trycatch.HasTerminated()) {
-    result_type = type_terminated_exception;
-  }
-
-  return bv_factory_->FromExceptionMessage(context, trycatch.Message(),
-                                           trycatch.Exception(), result_type);
-}
-
-auto CodeEvaluator::GetFunction(v8::Isolate* isolate,
-                                const std::string& code,
-                                v8::Local<v8::Context>& context,
-                                v8::Local<v8::Function>* func) -> bool {
-  // Is it a single function call?
-  // Does the code string end with '()'?
-  if (code.size() < 3 || code[code.size() - 2] != '(' ||
-      code[code.size() - 1] != ')') {
-    return false;
-  }
-
-  // Check if the value before the () is a callable identifier:
-  const v8::MaybeLocal<v8::String> maybe_identifier =
-      v8::String::NewFromUtf8(isolate, code.data(), v8::NewStringType::kNormal,
-                              static_cast<int>(code.size() - 2));
-  v8::Local<v8::String> identifier;
-  if (!maybe_identifier.ToLocal(&identifier)) {
-    return false;
-  }
-
-  v8::Local<v8::Value> func_val;
-  if (!context->Global()->Get(context, identifier).ToLocal(&func_val)) {
-    return false;
-  }
-
-  if (!func_val->IsFunction()) {
-    return false;
-  }
-
-  *func = func_val.As<v8::Function>();
-  return true;
-}
-
-auto CodeEvaluator::EvalFunction(v8::Isolate* isolate,
-                                 const v8::Local<v8::Function>& func,
-                                 v8::Local<v8::Context>& context)
-    -> BinaryValue::Ptr {
-  const v8::TryCatch trycatch(isolate);
-
-  v8::MaybeLocal<v8::Value> maybe_value =
-      func->Call(context, v8::Undefined(isolate), 0, {});
-  if (!maybe_value.IsEmpty()) {
-    return bv_factory_->FromValue(context, maybe_value.ToLocalChecked());
-  }
-
-  return SummarizeTryCatch(context, trycatch);
-}
-
-auto CodeEvaluator::EvalAsScript(v8::Isolate* isolate,
-                                 const std::string& code,
-                                 v8::Local<v8::Context>& context)
-    -> BinaryValue::Ptr {
   const v8::TryCatch trycatch(isolate);
 
   v8::MaybeLocal<v8::String> maybe_string =
@@ -122,31 +60,17 @@ auto CodeEvaluator::EvalAsScript(v8::Isolate* isolate,
   }
 
   // Didn't execute. Find an error:
-  return SummarizeTryCatch(context, trycatch);
-}
-
-auto CodeEvaluator::Eval(v8::Isolate* isolate,
-                         const std::string& code) -> BinaryValue::Ptr {
-  const v8::Isolate::Scope isolate_scope(isolate);
-  const v8::HandleScope handle_scope(isolate);
-  v8::Local<v8::Context> context = context_->Get(isolate);
-  const v8::Context::Scope context_scope(context);
-
-  // Try and evaluate as a simple function call.
-  // This gets us a speedup of about 1.17 (i.e., 17% faster) on a baseline of
-  // no-op function calls. It's not much, but it provides an easy way for users
-  // to eek out performance without exposing a pre-compiled scripts API: users
-  // can simply globally *define* all their functions in one (or more) eval
-  // call(s), and then *call* them in another.
-  v8::Local<v8::Function> func;
-  if (GetFunction(isolate, code, context, &func)) {
-    function_eval_call_count_++;
-    return EvalFunction(isolate, func, context);
+  if (memory_monitor_->IsHardMemoryLimitReached()) {
+    return bv_factory_->FromString("", type_oom_exception);
   }
 
-  // Fall back on a slower full eval:
-  full_eval_call_count_++;
-  return EvalAsScript(isolate, code, context);
+  BinaryTypes result_type = type_execute_exception;
+  if (trycatch.HasTerminated()) {
+    result_type = type_terminated_exception;
+  }
+
+  return bv_factory_->FromExceptionMessage(context, trycatch.Message(),
+                                           trycatch.Exception(), result_type);
 }
 
 }  // end namespace MiniRacer

--- a/src/v8_py_frontend/code_evaluator.h
+++ b/src/v8_py_frontend/code_evaluator.h
@@ -6,8 +6,6 @@
 #include <v8-isolate.h>
 #include <v8-local-handle.h>
 #include <v8-persistent-handle.h>
-#include <atomic>
-#include <cstdint>
 #include <string>
 #include "binary_value.h"
 #include "isolate_memory_monitor.h"
@@ -23,38 +21,11 @@ class CodeEvaluator {
 
   auto Eval(v8::Isolate* isolate, const std::string& code) -> BinaryValue::Ptr;
 
-  [[nodiscard]] auto FunctionEvalCallCount() const -> uint64_t;
-  [[nodiscard]] auto FullEvalCallCount() const -> uint64_t;
-
  private:
-  auto SummarizeTryCatch(v8::Local<v8::Context>& context,
-                         const v8::TryCatch& trycatch) -> BinaryValue::Ptr;
-
-  static auto GetFunction(v8::Isolate* isolate,
-                          const std::string& code,
-                          v8::Local<v8::Context>& context,
-                          v8::Local<v8::Function>* func) -> bool;
-  auto EvalFunction(v8::Isolate* isolate,
-                    const v8::Local<v8::Function>& func,
-                    v8::Local<v8::Context>& context) -> BinaryValue::Ptr;
-  auto EvalAsScript(v8::Isolate* isolate,
-                    const std::string& code,
-                    v8::Local<v8::Context>& context) -> BinaryValue::Ptr;
-
   v8::Persistent<v8::Context>* context_;
   BinaryValueFactory* bv_factory_;
   IsolateMemoryMonitor* memory_monitor_;
-  std::atomic<uint64_t> function_eval_call_count_{0};
-  std::atomic<uint64_t> full_eval_call_count_{0};
 };
-
-inline auto CodeEvaluator::FunctionEvalCallCount() const -> uint64_t {
-  return function_eval_call_count_;
-}
-
-inline auto CodeEvaluator::FullEvalCallCount() const -> uint64_t {
-  return full_eval_call_count_;
-}
 
 }  // end namespace MiniRacer
 

--- a/src/v8_py_frontend/exports.cc
+++ b/src/v8_py_frontend/exports.cc
@@ -149,14 +149,4 @@ LIB_EXPORT auto mr_heap_snapshot(MiniRacer::Context* mr_context,
   return mr_context->HeapSnapshot(callback, cb_data).release();
 }
 
-LIB_EXPORT auto mr_full_eval_call_count(MiniRacer::Context* mr_context)
-    -> uint64_t {
-  return mr_context->FullEvalCallCount();
-}
-
-LIB_EXPORT auto mr_function_eval_call_count(MiniRacer::Context* mr_context)
-    -> uint64_t {
-  return mr_context->FunctionEvalCallCount();
-}
-
 }  // end extern "C"

--- a/src/v8_py_frontend/exports.cc
+++ b/src/v8_py_frontend/exports.cc
@@ -130,6 +130,14 @@ LIB_EXPORT auto mr_splice_array(MiniRacer::Context* mr_context,
       .release();
 }
 
+LIB_EXPORT auto mr_call_function(MiniRacer::Context* mr_context,
+                                 MiniRacer::BinaryValue* func_ptr,
+                                 MiniRacer::BinaryValue* this_ptr,
+                                 MiniRacer::BinaryValue* argv)
+    -> MiniRacer::BinaryValue* {
+  return mr_context->CallFunction(func_ptr, this_ptr, argv).release();
+}
+
 // FOR DEBUGGING ONLY
 LIB_EXPORT auto mr_heap_snapshot(MiniRacer::Context* mr_context,
                                  MiniRacer::Callback callback,

--- a/src/v8_py_frontend/exports.cc
+++ b/src/v8_py_frontend/exports.cc
@@ -133,9 +133,12 @@ LIB_EXPORT auto mr_splice_array(MiniRacer::Context* mr_context,
 LIB_EXPORT auto mr_call_function(MiniRacer::Context* mr_context,
                                  MiniRacer::BinaryValue* func_ptr,
                                  MiniRacer::BinaryValue* this_ptr,
-                                 MiniRacer::BinaryValue* argv)
-    -> MiniRacer::BinaryValue* {
-  return mr_context->CallFunction(func_ptr, this_ptr, argv).release();
+                                 MiniRacer::BinaryValue* argv,
+                                 MiniRacer::Callback callback,
+                                 void* cb_data)
+    -> MiniRacer::CancelableTaskHandle* {
+  return mr_context->CallFunction(func_ptr, this_ptr, argv, callback, cb_data)
+      .release();
 }
 
 // FOR DEBUGGING ONLY

--- a/src/v8_py_frontend/mini_racer.cc
+++ b/src/v8_py_frontend/mini_racer.cc
@@ -178,4 +178,16 @@ void Context::FreeBinaryValue(gsl::owner<BinaryValue*> val) {
   bv_factory_.Free(val);
 }
 
+auto Context::CallFunction(BinaryValue* func_ptr,
+                           BinaryValue* this_ptr,
+                           BinaryValue* argv) -> BinaryValue::Ptr {
+  return isolate_manager_.RunAndAwait(
+      [func_ptr, this, this_ptr, argv](v8::Isolate* isolate) {
+        const v8::HandleScope handle_scope(isolate);
+        return object_manipulator_.Call(
+            isolate, bv_factory_.GetPersistentHandle(isolate, func_ptr),
+            this_ptr, argv);
+      });
+}
+
 }  // end namespace MiniRacer

--- a/src/v8_py_frontend/mini_racer.cc
+++ b/src/v8_py_frontend/mini_racer.cc
@@ -180,14 +180,18 @@ void Context::FreeBinaryValue(gsl::owner<BinaryValue*> val) {
 
 auto Context::CallFunction(BinaryValue* func_ptr,
                            BinaryValue* this_ptr,
-                           BinaryValue* argv) -> BinaryValue::Ptr {
-  return isolate_manager_.RunAndAwait(
+                           BinaryValue* argv,
+                           Callback callback,
+                           void* cb_data)
+    -> std::unique_ptr<CancelableTaskHandle> {
+  return RunTask(
       [func_ptr, this, this_ptr, argv](v8::Isolate* isolate) {
         const v8::HandleScope handle_scope(isolate);
         return object_manipulator_.Call(
             isolate, bv_factory_.GetPersistentHandle(isolate, func_ptr),
             this_ptr, argv);
-      });
+      },
+      callback, cb_data);
 }
 
 }  // end namespace MiniRacer

--- a/src/v8_py_frontend/mini_racer.h
+++ b/src/v8_py_frontend/mini_racer.h
@@ -52,6 +52,9 @@ class Context {
                    int32_t start,
                    int32_t delete_count,
                    BinaryValue* new_val) -> BinaryValue::Ptr;
+  auto CallFunction(BinaryValue* func_ptr,
+                    BinaryValue* this_ptr,
+                    BinaryValue* argv) -> BinaryValue::Ptr;
 
  private:
   template <typename Runnable>

--- a/src/v8_py_frontend/mini_racer.h
+++ b/src/v8_py_frontend/mini_racer.h
@@ -40,8 +40,6 @@ class Context {
   auto Eval(const std::string& code,
             Callback callback,
             void* cb_data) -> std::unique_ptr<CancelableTaskHandle>;
-  [[nodiscard]] auto FunctionEvalCallCount() const -> uint64_t;
-  [[nodiscard]] auto FullEvalCallCount() const -> uint64_t;
   void AttachPromiseThen(BinaryValue* bv_ptr, Callback callback, void* cb_data);
   auto GetIdentityHash(BinaryValue* bv_ptr) -> int;
   auto GetOwnPropertyNames(BinaryValue* bv_ptr) -> BinaryValue::Ptr;
@@ -100,14 +98,6 @@ inline auto Context::IsHardMemoryLimitReached() const -> bool {
 
 inline void Context::ApplyLowMemoryNotification() {
   isolate_memory_monitor_.ApplyLowMemoryNotification();
-}
-
-inline auto Context::FunctionEvalCallCount() const -> uint64_t {
-  return code_evaluator_.FunctionEvalCallCount();
-}
-
-inline auto Context::FullEvalCallCount() const -> uint64_t {
-  return code_evaluator_.FullEvalCallCount();
 }
 
 inline void Context::AttachPromiseThen(BinaryValue* bv_ptr,

--- a/src/v8_py_frontend/mini_racer.h
+++ b/src/v8_py_frontend/mini_racer.h
@@ -54,7 +54,9 @@ class Context {
                    BinaryValue* new_val) -> BinaryValue::Ptr;
   auto CallFunction(BinaryValue* func_ptr,
                     BinaryValue* this_ptr,
-                    BinaryValue* argv) -> BinaryValue::Ptr;
+                    BinaryValue* argv,
+                    Callback callback,
+                    void* cb_data) -> std::unique_ptr<CancelableTaskHandle>;
 
  private:
   template <typename Runnable>

--- a/src/v8_py_frontend/object_manipulator.h
+++ b/src/v8_py_frontend/object_manipulator.h
@@ -36,6 +36,10 @@ class ObjectManipulator {
               int32_t start,
               int32_t delete_count,
               BinaryValue* new_val) -> BinaryValue::Ptr;
+  auto Call(v8::Isolate* isolate,
+            v8::Local<v8::Value> func,
+            BinaryValue* this_ptr,
+            BinaryValue* argv_ptr) -> BinaryValue::Ptr;
 
  private:
   v8::Persistent<v8::Context>* context_;

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -1,0 +1,59 @@
+""" Tests JSFunctions """
+
+
+import pytest
+from py_mini_racer import (
+    JSEvalException,
+    MiniRacer,
+)
+
+
+def test_function():
+    mr = MiniRacer()
+    func = mr.eval("(a) => a")
+    assert func(42) == 42
+    arr = mr.eval("[41, 42]")
+    assert list(func(arr)) == list(func(arr))
+    thing = mr.eval(
+        """\
+class Thing {
+    constructor(a) {
+        this.blob = a;
+    }
+
+    stuff(extra) {
+        return this.blob + extra;
+    }
+}
+new Thing('start');
+"""
+    )
+    stuff = thing["stuff"]
+    assert stuff("end", this=thing) == "startend"
+
+
+def test_exceptions():
+    mr = MiniRacer()
+    func = mr.eval(
+        """\
+function func(a, b, c) {
+    throw new Error('asdf');
+}
+func
+"""
+    )
+
+    with pytest.raises(JSEvalException) as exc_info:
+        func()
+
+    assert (
+        exc_info.value.args[0]
+        == """\
+<anonymous>:2: Error: asdf
+    throw new Error('asdf');
+    ^
+
+Error: asdf
+    at func (<anonymous>:2:11)
+"""
+    )

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -4,6 +4,7 @@
 import pytest
 from py_mini_racer import (
     JSEvalException,
+    JSTimeoutException,
     MiniRacer,
 )
 
@@ -57,3 +58,12 @@ Error: asdf
     at func (<anonymous>:2:11)
 """
     )
+
+
+def test_timeout():
+    mr = MiniRacer()
+    func = mr.eval("() => { while(1) { } }")
+    with pytest.raises(JSTimeoutException) as exc_info:
+        func(timeout_sec=1)
+
+    assert exc_info.value.args[0] == "JavaScript was terminated by timeout"


### PR DESCRIPTION
This also removes an old optimization related to simple, no-argument functions in the `eval` method. See update to HISTORY.md for rationale.