### PR TITLE
Improve safety of creating and freeing BinaryValues

### DIFF
--- a/src/v8_py_frontend/exports.cc
+++ b/src/v8_py_frontend/exports.cc
@@ -1,5 +1,3 @@
-#include <v8-persistent-handle.h>
-#include <v8-value.h>
 #include <v8-version-string.h>
 #include <cstddef>
 #include <cstdint>
@@ -85,50 +83,50 @@ LIB_EXPORT auto mr_v8_version() -> char const* {
 }
 
 LIB_EXPORT void mr_attach_promise_then(MiniRacer::Context* mr_context,
-                                       v8::Persistent<v8::Value>* promise,
+                                       MiniRacer::BinaryValue* bv_ptr,
                                        MiniRacer::Callback callback,
                                        void* cb_data) {
-  mr_context->AttachPromiseThen(promise, callback, cb_data);
+  mr_context->AttachPromiseThen(bv_ptr, callback, cb_data);
 }
 
 LIB_EXPORT auto mr_get_identity_hash(MiniRacer::Context* mr_context,
-                                     v8::Persistent<v8::Value>* object) -> int {
-  return mr_context->GetIdentityHash(object);
+                                     MiniRacer::BinaryValue* bv_ptr) -> int {
+  return mr_context->GetIdentityHash(bv_ptr);
 }
 
 LIB_EXPORT auto mr_get_own_property_names(MiniRacer::Context* mr_context,
-                                          v8::Persistent<v8::Value>* object)
+                                          MiniRacer::BinaryValue* bv_ptr)
     -> MiniRacer::BinaryValue* {
-  return mr_context->GetOwnPropertyNames(object).release();
+  return mr_context->GetOwnPropertyNames(bv_ptr).release();
 }
 
 LIB_EXPORT auto mr_get_object_item(MiniRacer::Context* mr_context,
-                                   v8::Persistent<v8::Value>* object,
+                                   MiniRacer::BinaryValue* bv_ptr,
                                    MiniRacer::BinaryValue* key)
     -> gsl::owner<MiniRacer::BinaryValue*> {
-  return mr_context->GetObjectItem(object, key).release();
+  return mr_context->GetObjectItem(bv_ptr, key).release();
 }
 
 LIB_EXPORT void mr_set_object_item(MiniRacer::Context* mr_context,
-                                   v8::Persistent<v8::Value>* object,
+                                   MiniRacer::BinaryValue* bv_ptr,
                                    MiniRacer::BinaryValue* key,
                                    MiniRacer::BinaryValue* val) {
-  mr_context->SetObjectItem(object, key, val);
+  mr_context->SetObjectItem(bv_ptr, key, val);
 }
 
 LIB_EXPORT auto mr_del_object_item(MiniRacer::Context* mr_context,
-                                   v8::Persistent<v8::Value>* object,
+                                   MiniRacer::BinaryValue* bv_ptr,
                                    MiniRacer::BinaryValue* key) -> bool {
-  return mr_context->DelObjectItem(object, key);
+  return mr_context->DelObjectItem(bv_ptr, key);
 }
 
 LIB_EXPORT auto mr_splice_array(MiniRacer::Context* mr_context,
-                                v8::Persistent<v8::Value>* object,
+                                MiniRacer::BinaryValue* bv_ptr,
                                 int32_t start,
                                 int32_t delete_count,
                                 MiniRacer::BinaryValue* new_val)
     -> MiniRacer::BinaryValue* {
-  return mr_context->SpliceArray(object, start, delete_count, new_val)
+  return mr_context->SpliceArray(bv_ptr, start, delete_count, new_val)
       .release();
 }
 

--- a/src/v8_py_frontend/isolate_manager.cc
+++ b/src/v8_py_frontend/isolate_manager.cc
@@ -34,9 +34,7 @@ void IsolateManager::PumpMessages() {
       break;
     }
 
-    if (!shutdown_) {
-      v8::MicrotasksScope::PerformCheckpoint(isolate_holder_.Get());
-    }
+    v8::MicrotasksScope::PerformCheckpoint(isolate_holder_.Get());
   }
 }
 
@@ -56,7 +54,7 @@ IsolateManager::~IsolateManager() {
 
   // From v8/src/d8/d8.cc Worker::Terminate():
   // Terminate any ongoing execution (in case some JS is running forever):
-  isolate_holder_.Get()->TerminateExecution();
+  // isolate_holder_.Get()->TerminateExecution();
 
   thread_.join();
 }

--- a/src/v8_py_frontend/mini_racer.h
+++ b/src/v8_py_frontend/mini_racer.h
@@ -1,8 +1,6 @@
 #ifndef MINI_RACER_H
 #define MINI_RACER_H
 
-#include <v8-persistent-handle.h>
-#include <v8-value.h>
 #include <cstddef>
 #include <cstdint>
 #include <filesystem>
@@ -43,20 +41,13 @@ class Context {
             void* cb_data) -> std::unique_ptr<CancelableTaskHandle>;
   [[nodiscard]] auto FunctionEvalCallCount() const -> uint64_t;
   [[nodiscard]] auto FullEvalCallCount() const -> uint64_t;
-  void AttachPromiseThen(v8::Persistent<v8::Value>* promise,
-                         Callback callback,
-                         void* cb_data);
-  auto GetIdentityHash(v8::Persistent<v8::Value>* object) -> int;
-  auto GetOwnPropertyNames(v8::Persistent<v8::Value>* object)
-      -> BinaryValue::Ptr;
-  auto GetObjectItem(v8::Persistent<v8::Value>* object,
-                     BinaryValue* key) -> BinaryValue::Ptr;
-  void SetObjectItem(v8::Persistent<v8::Value>* object,
-                     BinaryValue* key,
-                     BinaryValue* val);
-  auto DelObjectItem(v8::Persistent<v8::Value>* object,
-                     BinaryValue* key) -> bool;
-  auto SpliceArray(v8::Persistent<v8::Value>* object,
+  void AttachPromiseThen(BinaryValue* bv_ptr, Callback callback, void* cb_data);
+  auto GetIdentityHash(BinaryValue* bv_ptr) -> int;
+  auto GetOwnPropertyNames(BinaryValue* bv_ptr) -> BinaryValue::Ptr;
+  auto GetObjectItem(BinaryValue* bv_ptr, BinaryValue* key) -> BinaryValue::Ptr;
+  void SetObjectItem(BinaryValue* bv_ptr, BinaryValue* key, BinaryValue* val);
+  auto DelObjectItem(BinaryValue* bv_ptr, BinaryValue* key) -> bool;
+  auto SpliceArray(BinaryValue* bv_ptr,
                    int32_t start,
                    int32_t delete_count,
                    BinaryValue* new_val) -> BinaryValue::Ptr;
@@ -102,10 +93,6 @@ inline void Context::ApplyLowMemoryNotification() {
   isolate_memory_monitor_.ApplyLowMemoryNotification();
 }
 
-inline void Context::FreeBinaryValue(gsl::owner<BinaryValue*> val) {
-  bv_factory_.Free(val);
-}
-
 inline auto Context::FunctionEvalCallCount() const -> uint64_t {
   return code_evaluator_.FunctionEvalCallCount();
 }
@@ -114,10 +101,10 @@ inline auto Context::FullEvalCallCount() const -> uint64_t {
   return code_evaluator_.FullEvalCallCount();
 }
 
-inline void Context::AttachPromiseThen(v8::Persistent<v8::Value>* promise,
+inline void Context::AttachPromiseThen(BinaryValue* bv_ptr,
                                        MiniRacer::Callback callback,
                                        void* cb_data) {
-  promise_attacher_.AttachPromiseThen(promise, callback, cb_data);
+  promise_attacher_.AttachPromiseThen(bv_ptr, callback, cb_data);
 }
 
 }  // namespace MiniRacer

--- a/src/v8_py_frontend/object_manipulator.h
+++ b/src/v8_py_frontend/object_manipulator.h
@@ -18,22 +18,21 @@ class ObjectManipulator {
                     BinaryValueFactory* bv_factory);
 
   static auto GetIdentityHash(v8::Isolate* isolate,
-                              v8::Persistent<v8::Value>* object) -> int;
-  auto GetOwnPropertyNames(v8::Isolate* isolate,
-                           v8::Persistent<v8::Value>* object) const
-      -> BinaryValue::Ptr;
+                              v8::Local<v8::Value> object) -> int;
+  auto GetOwnPropertyNames(v8::Isolate* isolate, v8::Local<v8::Value> object)
+      const -> BinaryValue::Ptr;
   auto Get(v8::Isolate* isolate,
-           v8::Persistent<v8::Value>* object,
+           v8::Local<v8::Value> object,
            BinaryValue* key) -> BinaryValue::Ptr;
   void Set(v8::Isolate* isolate,
-           v8::Persistent<v8::Value>* object,
+           v8::Local<v8::Value> object,
            BinaryValue* key,
            BinaryValue* val);
   auto Del(v8::Isolate* isolate,
-           v8::Persistent<v8::Value>* object,
+           v8::Local<v8::Value> object,
            BinaryValue* key) -> bool;
   auto Splice(v8::Isolate* isolate,
-              v8::Persistent<v8::Value>* object,
+              v8::Local<v8::Value> object,
               int32_t start,
               int32_t delete_count,
               BinaryValue* new_val) -> BinaryValue::Ptr;

--- a/src/v8_py_frontend/promise_attacher.cc
+++ b/src/v8_py_frontend/promise_attacher.cc
@@ -24,15 +24,16 @@ PromiseAttacher::PromiseAttacher(IsolateManager* isolate_manager,
       context_(context),
       bv_factory_(bv_factory) {}
 
-void PromiseAttacher::AttachPromiseThen(v8::Persistent<v8::Value>* promise_val,
+void PromiseAttacher::AttachPromiseThen(BinaryValue* bv_ptr,
                                         Callback callback,
                                         void* cb_data) {
-  isolate_manager_->RunAndAwait([promise_val, callback, cb_data,
+  isolate_manager_->RunAndAwait([bv_ptr, callback, cb_data,
                                  this](v8::Isolate* isolate) {
     const v8::Locker lock(isolate);
     const v8::HandleScope scope(isolate);
 
-    const v8::Local<v8::Value> value = promise_val->Get(isolate);
+    const v8::Local<v8::Value> value =
+        bv_factory_->GetPersistentHandle(isolate, bv_ptr);
     const v8::Local<v8::Promise> promise = value.As<v8::Promise>();
 
     // Note that completion_handler will be deleted by whichever callback is

--- a/src/v8_py_frontend/promise_attacher.h
+++ b/src/v8_py_frontend/promise_attacher.h
@@ -17,9 +17,7 @@ class PromiseAttacher {
                   v8::Persistent<v8::Context>* context,
                   BinaryValueFactory* bv_factory);
 
-  void AttachPromiseThen(v8::Persistent<v8::Value>* promise_val,
-                         Callback callback,
-                         void* cb_data);
+  void AttachPromiseThen(BinaryValue* bv_ptr, Callback callback, void* cb_data);
 
  private:
   IsolateManager* isolate_manager_;


### PR DESCRIPTION
Several related things:

1. Instead of passing raw `v8::Persistent` pointers from C++ to Python, store a mapping from `BinaryValue*` object IDs `v8::Persistent` in the `BinaryValueFactory` from C++ to Python, similarly to how `ArrayBuffer`s already work. This simplifies the Python side (it can refer to Objects using the `BinaryValue` pointer *only*, rather than maintaining a `BinaryValue` pointer for memory-management purposes and a `v8::Persistent` pointer for actual API calls).

2. When freeing `v8::Persistent` pointers *and* `ArrayBuffer` `backing_store` instances, do so on the isolate message pump. This was probably a thread safety bug. (I didn't see any crashes, and the documentation doesn't say whether you can `delete v8::Persistent<...>` or decref your `backing_store` handle without the `Isolate` lock, but generally this was probably unsafe.) To avoid deadlocks related to callbacks to Python (which may re-enter the C++ MiniRacer code to free stuff), we only *enqueue* the objects for freeing, but don't actually block on the result.

These changes are related: because we only free `v8::Persistent` objects asynchronously (on the message loop) now, it's possible, probably, that some will still be unreclaimed when the `MiniRacer::Context` shuts off the message loop. No problem! `BinaryValueFactory` knows about all the persistent handles and will free them when it is, itself, destructed.

Also:

3. Add a mutex around the `backing_store` mapping. Its absence was a bug.