### PR TITLE
Fix teardown bugs

### DIFF
--- a/src/v8_py_frontend/BUILD.gn
+++ b/src/v8_py_frontend/BUILD.gn
@@ -12,6 +12,8 @@ v8_shared_library("mini_racer") {
     "code_evaluator.cc",
     "context_holder.h",
     "context_holder.cc",
+    "count_down_latch.h",
+    "count_down_latch.cc",
     "gsl_stub.h",
     "heap_reporter.h",
     "heap_reporter.cc",

--- a/src/v8_py_frontend/count_down_latch.cc
+++ b/src/v8_py_frontend/count_down_latch.cc
@@ -1,0 +1,35 @@
+#include "count_down_latch.h"
+
+#include <condition_variable>
+#include <mutex>
+
+namespace MiniRacer {
+
+void CountDownLatch::Increment() {
+  const std::lock_guard<std::mutex> lock(mutex_);
+  count_++;
+}
+
+void CountDownLatch::Decrement() {
+  const std::lock_guard<std::mutex> lock(mutex_);
+  count_--;
+
+  if (count_ == 0) {
+    cv_.notify_all();
+  }
+}
+
+void CountDownLatch::Wait() {
+  std::unique_lock<std::mutex> lock(mutex_);
+
+  cv_.wait(lock, [this] { return count_ == 0; });
+}
+
+CountDownLatchWaiter::CountDownLatchWaiter(CountDownLatch* latch)
+    : latch_(latch) {}
+
+CountDownLatchWaiter::~CountDownLatchWaiter() {
+  latch_->Wait();
+}
+
+}  // end namespace MiniRacer

--- a/src/v8_py_frontend/count_down_latch.h
+++ b/src/v8_py_frontend/count_down_latch.h
@@ -1,0 +1,40 @@
+#ifndef INCLUDE_MINI_RACER_COUNT_DOWN_LATCH_H
+#define INCLUDE_MINI_RACER_COUNT_DOWN_LATCH_H
+
+#include <condition_variable>
+#include <cstdint>
+#include <mutex>
+
+namespace MiniRacer {
+
+class CountDownLatch {
+ public:
+  void Increment();
+  void Decrement();
+  void Wait();
+
+ private:
+  std::mutex mutex_;
+  std::condition_variable cv_;
+  int64_t count_{0};
+};
+
+/** Calls latch->Wait() in its destructor. */
+class CountDownLatchWaiter {
+ public:
+  explicit CountDownLatchWaiter(CountDownLatch* latch);
+  ~CountDownLatchWaiter();
+
+  CountDownLatchWaiter(const CountDownLatchWaiter&) = delete;
+  auto operator=(const CountDownLatchWaiter&) -> CountDownLatchWaiter& = delete;
+  CountDownLatchWaiter(CountDownLatchWaiter&&) = delete;
+  auto operator=(CountDownLatchWaiter&& other) -> CountDownLatchWaiter& =
+                                                      delete;
+
+ private:
+  CountDownLatch* latch_;
+};
+
+}  // end namespace MiniRacer
+
+#endif  // INCLUDE_MINI_RACER_COUNT_DOWN_LATCH_H

--- a/src/v8_py_frontend/isolate_manager.h
+++ b/src/v8_py_frontend/isolate_manager.h
@@ -28,12 +28,6 @@ namespace MiniRacer {
 class IsolateManager {
  public:
   explicit IsolateManager(v8::Platform* platform);
-  ~IsolateManager();
-
-  IsolateManager(const IsolateManager&) = delete;
-  auto operator=(const IsolateManager&) -> IsolateManager& = delete;
-  IsolateManager(IsolateManager&&) = delete;
-  auto operator=(IsolateManager&& other) -> IsolateManager& = delete;
 
   /** Schedules a task to run on the foreground thread, using
    * v8::TaskRunner::PostTask. */
@@ -47,6 +41,8 @@ class IsolateManager {
       -> std::invoke_result_t<Runnable, v8::Isolate*>;
 
   void TerminateOngoingTask();
+
+  void Shutdown();
 
  private:
   void PumpMessages();
@@ -70,6 +66,22 @@ class IsolateManager {
   std::shared_ptr<v8::TaskRunner> task_runner_;
   std::atomic<bool> shutdown_;
   std::thread thread_;
+};
+
+class IsolateManagerStopper {
+ public:
+  explicit IsolateManagerStopper(IsolateManager* isolate_manager);
+  ~IsolateManagerStopper();
+
+  IsolateManagerStopper(const IsolateManagerStopper&) = delete;
+  auto operator=(const IsolateManagerStopper&) -> IsolateManagerStopper& =
+                                                      delete;
+  IsolateManagerStopper(IsolateManagerStopper&&) = delete;
+  auto operator=(IsolateManagerStopper&& other) -> IsolateManagerStopper& =
+                                                       delete;
+
+ private:
+  IsolateManager* isolate_manager_;
 };
 
 /** Just a silly way to run code on the foreground task runner thread. */

--- a/src/v8_py_frontend/mini_racer.h
+++ b/src/v8_py_frontend/mini_racer.h
@@ -11,6 +11,7 @@
 #include "cancelable_task_runner.h"
 #include "code_evaluator.h"
 #include "context_holder.h"
+#include "count_down_latch.h"
 #include "gsl_stub.h"
 #include "heap_reporter.h"
 #include "isolate_manager.h"
@@ -59,6 +60,7 @@ class Context {
                void* cb_data) -> std::unique_ptr<CancelableTaskHandle>;
 
   IsolateManager isolate_manager_;
+  IsolateManagerStopper isolate_manager_stopper_;
   IsolateMemoryMonitor isolate_memory_monitor_;
   BinaryValueFactory bv_factory_;
   ContextHolder context_holder_;
@@ -67,6 +69,8 @@ class Context {
   PromiseAttacher promise_attacher_;
   ObjectManipulator object_manipulator_;
   CancelableTaskRunner cancelable_task_runner_;
+  CountDownLatch pending_task_counter_;
+  CountDownLatchWaiter pending_task_waiter_;
 };
 
 void init_v8(const std::string& v8_flags,


### PR DESCRIPTION
Two things:

1. Remove reliance on `__del__` for freeing binary values, because it doesn't always happen in the right order (which in follow-on work, was segfaulting in the tests). Now, `__del__` is only an optional nice-to-have release of memory, and the `MiniRacer::Context` will delete any dangling binary values when it exits.

2. Make sure `MiniRacer::Context` shutdown is orderly wrt async tasks. Before it was possible (never saw it happen, but possible) for Python to start an `eval` task, then start destructing the `Context` before the `eval` gets going, resulting in dangling references to `Context` internals. This is no longer possible because the `Context` awaits any pending async tasks before commencing teardown.

This lets us remove half of the comment in `BinaryValueFactory::SavePersistentHandle` about the map of `v8::Persistent` objects being useful for cleaning up any leftover garbage. The new destruction-time loop over remaining `BinaryValue` pointers should now clean out the `v8::Persistent` map systematically, by calling `BinaryValueFactory::DeletePersistentHandle` for each.