### PR TITLE
Switch from py_object ptrs to uint64_t callback IDs

### DIFF
--- a/src/v8_py_frontend/callback.h
+++ b/src/v8_py_frontend/callback.h
@@ -1,11 +1,12 @@
 #ifndef INCLUDE_MINI_RACER_CALLBACK_H
 #define INCLUDE_MINI_RACER_CALLBACK_H
 
+#include <cstdint>
 #include "binary_value.h"
 
 namespace MiniRacer {
 
-using Callback = void (*)(void*, BinaryValueHandle*);
+using Callback = void (*)(uint64_t, BinaryValueHandle*);
 
 }  // end namespace MiniRacer
 

--- a/src/v8_py_frontend/exports.cc
+++ b/src/v8_py_frontend/exports.cc
@@ -19,8 +19,10 @@ LIB_EXPORT auto mr_eval(MiniRacer::Context* mr_context,
                         char* str,
                         uint64_t len,
                         MiniRacer::Callback callback,
-                        void* cb_data) -> MiniRacer::CancelableTaskHandle* {
-  return mr_context->Eval(std::string(str, len), callback, cb_data).release();
+                        uint64_t callback_id)
+    -> MiniRacer::CancelableTaskHandle* {
+  return mr_context->Eval(std::string(str, len), callback, callback_id)
+      .release();
 }
 
 LIB_EXPORT void mr_init_v8(const char* v8_flags,
@@ -71,9 +73,9 @@ LIB_EXPORT void mr_free_task_handle(
 
 LIB_EXPORT auto mr_heap_stats(MiniRacer::Context* mr_context,
                               MiniRacer::Callback callback,
-                              void* cb_data)
+                              uint64_t callback_id)
     -> MiniRacer::CancelableTaskHandle* {
-  return mr_context->HeapStats(callback, cb_data).release();
+  return mr_context->HeapStats(callback, callback_id).release();
 }
 
 LIB_EXPORT void mr_set_hard_memory_limit(MiniRacer::Context* mr_context,
@@ -108,8 +110,8 @@ LIB_EXPORT void mr_attach_promise_then(
     MiniRacer::Context* mr_context,
     MiniRacer::BinaryValueHandle* promise_handle,
     MiniRacer::Callback callback,
-    void* cb_data) {
-  mr_context->AttachPromiseThen(promise_handle, callback, cb_data);
+    uint64_t callback_id) {
+  mr_context->AttachPromiseThen(promise_handle, callback, callback_id);
 }
 
 LIB_EXPORT auto mr_get_identity_hash(MiniRacer::Context* mr_context,
@@ -161,19 +163,20 @@ LIB_EXPORT auto mr_call_function(MiniRacer::Context* mr_context,
                                  MiniRacer::BinaryValueHandle* this_handle,
                                  MiniRacer::BinaryValueHandle* argv_handle,
                                  MiniRacer::Callback callback,
-                                 void* cb_data)
+                                 uint64_t callback_id)
     -> MiniRacer::CancelableTaskHandle* {
   return mr_context
-      ->CallFunction(func_handle, this_handle, argv_handle, callback, cb_data)
+      ->CallFunction(func_handle, this_handle, argv_handle, callback,
+                     callback_id)
       .release();
 }
 
 // FOR DEBUGGING ONLY
 LIB_EXPORT auto mr_heap_snapshot(MiniRacer::Context* mr_context,
                                  MiniRacer::Callback callback,
-                                 void* cb_data)
+                                 uint64_t callback_id)
     -> MiniRacer::CancelableTaskHandle* {
-  return mr_context->HeapSnapshot(callback, cb_data).release();
+  return mr_context->HeapSnapshot(callback, callback_id).release();
 }
 
 LIB_EXPORT auto mr_value_count(MiniRacer::Context* mr_context) -> size_t {

--- a/src/v8_py_frontend/mini_racer.h
+++ b/src/v8_py_frontend/mini_racer.h
@@ -34,16 +34,16 @@ class Context {
   void FreeBinaryValue(BinaryValueHandle* val);
   template <typename... Params>
   auto AllocBinaryValue(Params&&... params) -> BinaryValueHandle*;
-  auto HeapSnapshot(Callback callback,
-                    void* cb_data) -> std::unique_ptr<CancelableTaskHandle>;
+  auto HeapSnapshot(Callback callback, uint64_t callback_id)
+      -> std::unique_ptr<CancelableTaskHandle>;
   auto HeapStats(Callback callback,
-                 void* cb_data) -> std::unique_ptr<CancelableTaskHandle>;
+                 uint64_t callback_id) -> std::unique_ptr<CancelableTaskHandle>;
   auto Eval(const std::string& code,
             Callback callback,
-            void* cb_data) -> std::unique_ptr<CancelableTaskHandle>;
+            uint64_t callback_id) -> std::unique_ptr<CancelableTaskHandle>;
   auto AttachPromiseThen(BinaryValueHandle* promise_handle,
                          Callback callback,
-                         void* cb_data) -> BinaryValueHandle*;
+                         uint64_t callback_id) -> BinaryValueHandle*;
   auto GetIdentityHash(BinaryValueHandle* obj_handle) -> BinaryValueHandle*;
   auto GetOwnPropertyNames(BinaryValueHandle* obj_handle) -> BinaryValueHandle*;
   auto GetObjectItem(BinaryValueHandle* obj_handle,
@@ -61,14 +61,15 @@ class Context {
                     BinaryValueHandle* this_handle,
                     BinaryValueHandle* argv_handle,
                     Callback callback,
-                    void* cb_data) -> std::unique_ptr<CancelableTaskHandle>;
+                    uint64_t callback_id)
+      -> std::unique_ptr<CancelableTaskHandle>;
   auto BinaryValueCount() -> size_t;
 
  private:
   template <typename Runnable>
   auto RunTask(Runnable runnable,
                Callback callback,
-               void* cb_data) -> std::unique_ptr<CancelableTaskHandle>;
+               uint64_t callback_id) -> std::unique_ptr<CancelableTaskHandle>;
 
   IsolateManager isolate_manager_;
   IsolateManagerStopper isolate_manager_stopper_;

--- a/src/v8_py_frontend/promise_attacher.h
+++ b/src/v8_py_frontend/promise_attacher.h
@@ -5,6 +5,7 @@
 #include <v8-function-callback.h>
 #include <v8-isolate.h>
 #include <v8-persistent-handle.h>
+#include <cstdint>
 #include "binary_value.h"
 #include "callback.h"
 
@@ -18,7 +19,7 @@ class PromiseAttacher {
   auto AttachPromiseThen(v8::Isolate* isolate,
                          BinaryValue* promise_ptr,
                          Callback callback,
-                         void* cb_data) -> BinaryValue::Ptr;
+                         uint64_t callback_id) -> BinaryValue::Ptr;
 
  private:
   v8::Persistent<v8::Context>* context_;
@@ -29,7 +30,7 @@ class PromiseCompletionHandler {
  public:
   PromiseCompletionHandler(BinaryValueFactory* bv_factory,
                            Callback callback_,
-                           void* cb_data);
+                           uint64_t callback_id);
 
   static void OnFulfilledStatic(
       const v8::FunctionCallbackInfo<v8::Value>& info);
@@ -41,7 +42,7 @@ class PromiseCompletionHandler {
 
   BinaryValueFactory* bv_factory_;
   Callback callback_;
-  void* cb_data_;
+  uint64_t callback_id_;
 };
 
 }  // namespace MiniRacer


### PR DESCRIPTION
In the cases where the C++ side needs to call back into Python (for all `eval` operations, as well as `Promise` callbacks), we have been using [the `ctypes` `py_object` feature](https://docs.python.org/3/library/ctypes.html#ctypes.py_object), which automatically wraps Python objects as they're passed in and out of the native (C/C++) side.

The `ctypes` `py_object` feature does some spooky undocumented magic related to `PyObject` reference counting. This is discussed briefly [on this StackOverflow](https://stackoverflow.com/questions/52967133/python3-ctypes-callback-causes-memory-leak-in-simple-example) but is not in [the `ctypes` docs](https://docs.python.org/3/library/ctypes.html). What it does works for us for now: every pass-in from Python to C++ increments the `PyObject` count, and every pass-back decrements it. However, it's unnecessary magic, particularly because we're already maintaining a collection of *other* don't-GC-me-objects in the `MiniRacer._async_callbacks` map, which the C++-side async work depends upon and which `ctypes` doesn't know about at all.

And using this feature in `ctypes.CDLL` mode (as opposed to `ctypes.PyDLL` mode, for DLLs which are *supposed* to understand Python) seems like a somewhat unexpected configuration. The idea that we're just using the `py_object` pointer as an opaque identifier on the C++ side, to be passed back to Python without any deep inspection, is not really the intended use case for `py_object`. This makes me worried about its operation in the future.

So let's simplify things and remove the magic, by passing `uint64_t` `callback_id`s to C++, keeping track of what those mean in our `_async_callbacks` map. We thus signal to `ctypes` that the DLL is totally oblivious about Python, which was always true. This isn't any more complicated than what we *were* doing since we already had that map anyway.