### PR TITLE
Move internal Python stuff to a _Context class

### DIFF
--- a/tests/test_babel.py
+++ b/tests/test_babel.py
@@ -27,4 +27,4 @@ def test_babel():
     assert mr.eval("babel.eval(((x) => x * x)(8))") == 64
 
     collect()
-    assert mr.value_count() == 0
+    assert mr._ctx.value_count() == 0  # noqa: SLF001

--- a/tests/test_call.py
+++ b/tests/test_call.py
@@ -21,7 +21,7 @@ def test_call_js():
     assert mr.call("f", *list(range(20))) == 20
 
     collect()
-    assert mr.value_count() == 0
+    assert mr._ctx.value_count() == 0  # noqa: SLF001
 
 
 def test_call_custom_encoder():
@@ -43,4 +43,4 @@ def test_call_custom_encoder():
     assert mr.call("f", now, encoder=CustomEncoder) == now.isoformat()
 
     collect()
-    assert mr.value_count() == 0
+    assert mr._ctx.value_count() == 0  # noqa: SLF001

--- a/tests/test_eval.py
+++ b/tests/test_eval.py
@@ -36,7 +36,7 @@ ReferenceError: invalid is not defined
 
     del exc_info
     collect()
-    assert mr.value_count() == 0
+    assert mr._ctx.value_count() == 0  # noqa: SLF001
 
 
 def test_eval():
@@ -44,7 +44,7 @@ def test_eval():
     assert mr.eval("42") == 42
 
     collect()
-    assert mr.value_count() == 0
+    assert mr._ctx.value_count() == 0  # noqa: SLF001
 
 
 def test_blank():
@@ -54,7 +54,7 @@ def test_blank():
     assert mr.eval("\t") is JSUndefined
 
     collect()
-    assert mr.value_count() == 0
+    assert mr._ctx.value_count() == 0  # noqa: SLF001
 
 
 def test_global():
@@ -63,7 +63,7 @@ def test_global():
     assert mr.eval("xabc") == 22
 
     collect()
-    assert mr.value_count() == 0
+    assert mr._ctx.value_count() == 0  # noqa: SLF001
 
 
 def test_fun():
@@ -75,7 +75,7 @@ def test_fun():
     assert mr.eval("x(100)") == 101
 
     collect()
-    assert mr.value_count() == 0
+    assert mr._ctx.value_count() == 0  # noqa: SLF001
 
 
 def test_multiple_ctx():
@@ -91,9 +91,9 @@ def test_multiple_ctx():
     assert c3.eval("(x)") == 3
 
     collect()
-    assert c1.value_count() == 0
-    assert c2.value_count() == 0
-    assert c3.value_count() == 0
+    assert c1._ctx.value_count() == 0  # noqa: SLF001
+    assert c2._ctx.value_count() == 0  # noqa: SLF001
+    assert c3._ctx.value_count() == 0  # noqa: SLF001
 
 
 def test_exception_thrown():
@@ -121,7 +121,7 @@ Error: blah
 
     del exc_info
     collect()
-    assert mr.value_count() == 0
+    assert mr._ctx.value_count() == 0  # noqa: SLF001
 
 
 def test_string_thrown():
@@ -147,7 +147,7 @@ var f = function() {throw 'blah'};
 
     del exc_info
     collect()
-    assert mr.value_count() == 0
+    assert mr._ctx.value_count() == 0  # noqa: SLF001
 
 
 def test_cannot_parse():
@@ -170,7 +170,7 @@ SyntaxError: Unexpected end of input
 
     del exc_info
     collect()
-    assert mr.value_count() == 0
+    assert mr._ctx.value_count() == 0  # noqa: SLF001
 
 
 def test_null_byte():
@@ -184,7 +184,7 @@ def test_null_byte():
     assert result == s
 
     collect()
-    assert mr.value_count() == 0
+    assert mr._ctx.value_count() == 0  # noqa: SLF001
 
 
 def test_timeout():
@@ -204,7 +204,7 @@ def test_timeout():
 
     del exc_info
     collect()
-    assert mr.value_count() == 0
+    assert mr._ctx.value_count() == 0  # noqa: SLF001
 
 
 def test_timeout_ms():
@@ -225,7 +225,7 @@ def test_timeout_ms():
 
     del exc_info
     collect()
-    assert mr.value_count() == 0
+    assert mr._ctx.value_count() == 0  # noqa: SLF001
 
 
 def test_max_memory_soft():
@@ -253,7 +253,7 @@ while(true) {
 
     del exc_info
     collect()
-    assert mr.value_count() == 0
+    assert mr._ctx.value_count() == 0  # noqa: SLF001
 
 
 def test_max_memory_hard():
@@ -279,7 +279,7 @@ while(true) {
 
     del exc_info
     collect()
-    assert mr.value_count() == 0
+    assert mr._ctx.value_count() == 0  # noqa: SLF001
 
 
 def test_max_memory_hard_eval_arg():
@@ -306,7 +306,7 @@ while(true) {
 
     del exc_info
     collect()
-    assert mr.value_count() == 0
+    assert mr._ctx.value_count() == 0  # noqa: SLF001
 
 
 def test_symbol():
@@ -316,7 +316,7 @@ def test_symbol():
 
     del res
     collect()
-    assert mr.value_count() == 0
+    assert mr._ctx.value_count() == 0  # noqa: SLF001
 
 
 def test_microtask():
@@ -342,7 +342,7 @@ done
     assert mr.eval("done")
 
     collect()
-    assert mr.value_count() == 0
+    assert mr._ctx.value_count() == 0  # noqa: SLF001
 
 
 def test_polling():
@@ -363,7 +363,7 @@ done
     assert mr.eval("done")
 
     collect()
-    assert mr.value_count() == 0
+    assert mr._ctx.value_count() == 0  # noqa: SLF001
 
 
 def test_settimeout():
@@ -389,7 +389,7 @@ clearTimeout(b)
     assert mr.eval("results[2]") == "d"
 
     collect()
-    assert mr.value_count() == 0
+    assert mr._ctx.value_count() == 0  # noqa: SLF001
 
 
 def test_promise_sync():
@@ -409,7 +409,7 @@ new Promise((res, rej) => setTimeout(() => res(42), 1000)); // 1 s timeout
 
     del promise
     collect()
-    assert mr.value_count() == 0
+    assert mr._ctx.value_count() == 0  # noqa: SLF001
 
 
 @pytest.mark.asyncio
@@ -431,7 +431,7 @@ new Promise((res, rej) => setTimeout(() => res(42), 1000)); // 1 s timeout
 
     del promise
     collect()
-    assert mr.value_count() == 0
+    assert mr._ctx.value_count() == 0  # noqa: SLF001
 
 
 def test_resolved_promise_sync():
@@ -440,7 +440,7 @@ def test_resolved_promise_sync():
     assert val == 42
 
     collect()
-    assert mr.value_count() == 0
+    assert mr._ctx.value_count() == 0  # noqa: SLF001
 
 
 @pytest.mark.asyncio
@@ -450,4 +450,4 @@ async def test_resolved_promise_async():
     assert val == 42
 
     collect()
-    assert mr.value_count() == 0
+    assert mr._ctx.value_count() == 0  # noqa: SLF001

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -35,7 +35,7 @@ new Thing('start');
 
     del func, arr, thing, stuff
     collect()
-    assert mr.value_count() == 0
+    assert mr._ctx.value_count() == 0  # noqa: SLF001
 
 
 def test_exceptions():
@@ -66,7 +66,7 @@ Error: asdf
 
     del func, exc_info
     collect()
-    assert mr.value_count() == 0
+    assert mr._ctx.value_count() == 0  # noqa: SLF001
 
 
 def test_timeout():
@@ -79,4 +79,4 @@ def test_timeout():
 
     del func, exc_info
     collect()
-    assert mr.value_count() == 0
+    assert mr._ctx.value_count() == 0  # noqa: SLF001

--- a/tests/test_heap.py
+++ b/tests/test_heap.py
@@ -10,4 +10,4 @@ def test_heap_stats():
     assert mr.heap_stats()["total_heap_size"] > 0
 
     collect()
-    assert mr.value_count() == 0
+    assert mr._ctx.value_count() == 0  # noqa: SLF001

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,5 +1,7 @@
+from re import match
+
 import pytest
-from py_mini_racer import LibAlreadyInitializedError, init_mini_racer
+from py_mini_racer import LibAlreadyInitializedError, MiniRacer, init_mini_racer
 
 
 def test_init():
@@ -21,3 +23,8 @@ def test_init():
 #     mr = MiniRacer()
 #     # this would normally fail in strict JS mode because foo is not declared:
 #     mr.eval('foo = 4')
+
+
+def test_version():
+    mr = MiniRacer()
+    assert match(r"^\d+\.\d+\.\d+\.\d+$", mr.v8_version) is not None

--- a/tests/test_objects.py
+++ b/tests/test_objects.py
@@ -71,7 +71,7 @@ a
 
     del obj, obj2, obj3
     collect()
-    assert mr.value_count() == 0
+    assert mr._ctx.value_count() == 0  # noqa: SLF001
 
 
 def test_object_mutation():
@@ -120,7 +120,7 @@ b
 
     del obj, inner_obj
     collect()
-    assert mr.value_count() == 0
+    assert mr._ctx.value_count() == 0  # noqa: SLF001
 
 
 def test_object_prototype():
@@ -181,7 +181,7 @@ a
 
     del obj, obj2
     collect()
-    assert mr.value_count() == 0
+    assert mr._ctx.value_count() == 0  # noqa: SLF001
 
 
 def test_array_mutation():
@@ -223,7 +223,7 @@ b
 
     del obj, inner_obj
     collect()
-    assert mr.value_count() == 0
+    assert mr._ctx.value_count() == 0  # noqa: SLF001
 
 
 def test_function():
@@ -241,7 +241,7 @@ foo
 
     del obj
     collect()
-    assert mr.value_count() == 0
+    assert mr._ctx.value_count() == 0  # noqa: SLF001
 
 
 def test_symbol():
@@ -259,7 +259,7 @@ sym
 
     del obj
     collect()
-    assert mr.value_count() == 0
+    assert mr._ctx.value_count() == 0  # noqa: SLF001
 
 
 def test_promise():
@@ -277,7 +277,7 @@ p
 
     del promise
     collect()
-    assert mr.value_count() == 0
+    assert mr._ctx.value_count() == 0  # noqa: SLF001
 
 
 def test_nested_object():
@@ -317,4 +317,4 @@ a
 
     del obj
     collect()
-    assert mr.value_count() == 0
+    assert mr._ctx.value_count() == 0  # noqa: SLF001

--- a/tests/test_strict.py
+++ b/tests/test_strict.py
@@ -10,7 +10,7 @@ def test_basic_int():
     assert mr.execute("42") == 42
 
     collect()
-    assert mr.value_count() == 0
+    assert mr._ctx.value_count() == 0  # noqa: SLF001
 
 
 def test_basic_string():
@@ -18,7 +18,7 @@ def test_basic_string():
     assert mr.execute('"42"') == "42"
 
     collect()
-    assert mr.value_count() == 0
+    assert mr._ctx.value_count() == 0  # noqa: SLF001
 
 
 def test_basic_hash():
@@ -26,7 +26,7 @@ def test_basic_hash():
     assert mr.execute("{}") == {}
 
     collect()
-    assert mr.value_count() == 0
+    assert mr._ctx.value_count() == 0  # noqa: SLF001
 
 
 def test_basic_array():
@@ -34,7 +34,7 @@ def test_basic_array():
     assert mr.execute("[1, 2, 3]") == [1, 2, 3]
 
     collect()
-    assert mr.value_count() == 0
+    assert mr._ctx.value_count() == 0  # noqa: SLF001
 
 
 def test_call():
@@ -48,7 +48,7 @@ def test_call():
     assert mr.call("f", list(range(5))) == 5
 
     collect()
-    assert mr.value_count() == 0
+    assert mr._ctx.value_count() == 0  # noqa: SLF001
 
 
 def test_message():
@@ -58,4 +58,4 @@ def test_message():
 
     clear_frames(exc_info.tb)
     collect()
-    assert mr.value_count() == 0
+    assert mr._ctx.value_count() == 0  # noqa: SLF001

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -38,7 +38,7 @@ class Validator:
             _test_round_trip(self.mr, py_val)
 
         collect()
-        assert self.mr.value_count() == 0
+        assert self.mr._ctx.value_count() == 0  # noqa: SLF001
 
 
 def test_undefined():
@@ -51,7 +51,7 @@ def test_undefined():
 
     del undef
     collect()
-    assert mr.value_count() == 0
+    assert mr._ctx.value_count() == 0  # noqa: SLF001
 
 
 def test_str():
@@ -69,7 +69,7 @@ def test_unicode():
     _test_round_trip(mr, ustr)
 
     collect()
-    assert mr.value_count() == 0
+    assert mr._ctx.value_count() == 0  # noqa: SLF001
 
 
 def test_numbers():
@@ -128,7 +128,7 @@ def test_object():
 
     del res
     collect()
-    assert mr.value_count() == 0
+    assert mr._ctx.value_count() == 0  # noqa: SLF001
 
 
 def test_timestamp():
@@ -139,7 +139,7 @@ def test_timestamp():
     _test_round_trip(mr, res)
 
     collect()
-    assert mr.value_count() == 0
+    assert mr._ctx.value_count() == 0  # noqa: SLF001
 
 
 def test_symbol():
@@ -151,7 +151,7 @@ def test_symbol():
 
     del res
     collect()
-    assert mr.value_count() == 0
+    assert mr._ctx.value_count() == 0  # noqa: SLF001
 
 
 def test_function():
@@ -163,7 +163,7 @@ def test_function():
 
     del res
     collect()
-    assert mr.value_count() == 0
+    assert mr._ctx.value_count() == 0  # noqa: SLF001
 
 
 def test_date():
@@ -174,7 +174,7 @@ def test_date():
 
     del res
     collect()
-    assert mr.value_count() == 0
+    assert mr._ctx.value_count() == 0  # noqa: SLF001
 
 
 def test_exception():
@@ -194,7 +194,7 @@ def test_exception():
 
     del exc_info
     collect()
-    assert mr.value_count() == 0
+    assert mr._ctx.value_count() == 0  # noqa: SLF001
 
 
 def test_array_buffer():
@@ -211,7 +211,7 @@ def test_array_buffer():
 
     del ret
     collect()
-    assert mr.value_count() == 0
+    assert mr._ctx.value_count() == 0  # noqa: SLF001
 
 
 def test_array_buffer_view():
@@ -228,7 +228,7 @@ def test_array_buffer_view():
 
     del ret
     collect()
-    assert mr.value_count() == 0
+    assert mr._ctx.value_count() == 0  # noqa: SLF001
 
 
 def test_shared_array_buffer():
@@ -247,4 +247,4 @@ def test_shared_array_buffer():
 
     del ret
     collect()
-    assert mr.value_count() == 0
+    assert mr._ctx.value_count() == 0  # noqa: SLF001

--- a/tests/test_wasm.py
+++ b/tests/test_wasm.py
@@ -47,4 +47,4 @@ def test_add():
 
     del module_raw
     collect()
-    assert mr.value_count() == 0
+    assert mr._ctx.value_count() == 0  # noqa: SLF001


### PR DESCRIPTION
Just cleaning out the parts of the Python `MiniRacer` class which aren't intended for use by `PyMiniRacer` users, so it's easier to understand.

This reduces the amount of time I have to turn off the `SLF001` check in production code, although it intentionally increases it in the test code (because I intentionally want to hide the memory-collection-verification API from ordinary `PyMiniRacer` users; it's just a hack for tests).