### PR TITLE
Fix segfault on longer microtasks

### DIFF
--- a/src/v8_py_frontend/isolate_manager.cc
+++ b/src/v8_py_frontend/isolate_manager.cc
@@ -24,6 +24,7 @@ void IsolateManager::PumpMessages() {
   // By the design of PyMiniRacer, only this, the message pump thread, is ever
   // allowed to touch the isolate, so go ahead and lock it:
   const v8::Locker lock(isolate_holder_.Get());
+  const v8::Isolate::Scope scope(isolate_holder_.Get());
 
   const v8::SealHandleScope shs(isolate_holder_.Get());
   while (!shutdown_) {


### PR DESCRIPTION
This resolves a bug which I think was introduced in v0.8.1. If you run a long enough microtask without this change, it segfaults Python. Before then, I think the microtask would have simply not run at all (because there was no ongoing loop which ran delayed microtasks).

(Take 2 on this PR, I just accidentally force-pushed over [Take 1](https://github.com/bpcreech/PyMiniRacer/pull/28). Need to protect the main branch!)