### PR TITLE
Verify the v8 sandbox is enabled

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -65,3 +65,7 @@ repos:
         - -extra-arg=-stdlib=libstdc++
         - -extra-arg=-isystem
         - -extra-arg=v8_workspace/v8/include
+        # The real build knows the sandbox is enabled but clang-tidy needs to be
+        # informed:
+        - -extra-arg=-DV8_ENABLE_SANDBOX
+        - -extra-arg=-DV8_COMPRESS_POINTERS

--- a/src/py_mini_racer/py_mini_racer.py
+++ b/src/py_mini_racer/py_mini_racer.py
@@ -492,6 +492,8 @@ def _build_dll_handle(dll_path) -> ctypes.CDLL:
 
     handle.mr_v8_version.restype = ctypes.c_char_p
 
+    handle.mr_v8_is_using_sandbox.restype = ctypes.c_bool
+
     handle.mr_value_count.argtypes = [ctypes.c_void_p]
     handle.mr_value_count.restype = ctypes.c_size_t
 
@@ -701,6 +703,11 @@ class _Context:
 
     def v8_version(self) -> str:
         return self._dll.mr_v8_version().decode("utf-8")
+
+    def v8_is_using_sandbox(self) -> bool:
+        """Checks for enablement of the V8 Sandbox. See https://v8.dev/blog/sandbox."""
+
+        return self._dll.mr_v8_is_using_sandbox()
 
     def evaluate(
         self,

--- a/src/v8_py_frontend/exports.cc
+++ b/src/v8_py_frontend/exports.cc
@@ -1,3 +1,4 @@
+#include <v8-initialization.h>
 #include <v8-version-string.h>
 #include <cstddef>
 #include <cstdint>
@@ -104,6 +105,10 @@ LIB_EXPORT void mr_low_memory_notification(MiniRacer::Context* mr_context) {
 
 LIB_EXPORT auto mr_v8_version() -> char const* {
   return V8_VERSION_STRING;
+}
+
+LIB_EXPORT auto mr_v8_is_using_sandbox() -> bool {
+  return v8::V8::IsSandboxConfiguredSecurely();
 }
 
 LIB_EXPORT void mr_attach_promise_then(

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -28,3 +28,8 @@ def test_init():
 def test_version():
     mr = MiniRacer()
     assert match(r"^\d+\.\d+\.\d+\.\d+$", mr.v8_version) is not None
+
+
+def test_sandbox():
+    mr = MiniRacer()
+    assert mr._ctx.v8_is_using_sandbox()  # noqa: SLF001


### PR DESCRIPTION
It's actually not quite trivial to answer [this question](https://github.com/bpcreech/PyMiniRacer/issues/25) about whether the V8 Sandbox is enabled on all platforms because the V8 build and runtime have lots of little gates on its enablement. So here's a test we can run a part of CI to assert that it's enabled on all target platforms.