### PR TITLE
Move to one callback function per Context

### DIFF
--- a/src/v8_py_frontend/context.h
+++ b/src/v8_py_frontend/context.h
@@ -20,7 +20,7 @@ namespace MiniRacer {
 
 class Context {
  public:
-  explicit Context(v8::Platform* platform);
+  explicit Context(v8::Platform* platform, Callback callback);
 
   void SetHardMemoryLimit(size_t limit);
   void SetSoftMemoryLimit(size_t limit);
@@ -33,13 +33,13 @@ class Context {
   template <typename... Params>
   auto AllocBinaryValue(Params&&... params) -> BinaryValueHandle*;
   void CancelTask(uint64_t task_id);
-  auto HeapSnapshot(Callback callback, uint64_t callback_id) -> uint64_t;
-  auto HeapStats(Callback callback, uint64_t callback_id) -> uint64_t;
+  auto HeapSnapshot(uint64_t callback_id) -> uint64_t;
+  auto HeapStats(uint64_t callback_id) -> uint64_t;
   auto Eval(BinaryValueHandle* code_handle,
-            Callback callback,
+
             uint64_t callback_id) -> uint64_t;
   auto AttachPromiseThen(BinaryValueHandle* promise_handle,
-                         Callback callback,
+
                          uint64_t callback_id) -> BinaryValueHandle*;
   auto GetIdentityHash(BinaryValueHandle* obj_handle) -> BinaryValueHandle*;
   auto GetOwnPropertyNames(BinaryValueHandle* obj_handle) -> BinaryValueHandle*;
@@ -57,16 +57,17 @@ class Context {
   auto CallFunction(BinaryValueHandle* func_handle,
                     BinaryValueHandle* this_handle,
                     BinaryValueHandle* argv_handle,
-                    Callback callback,
+
                     uint64_t callback_id) -> uint64_t;
   auto BinaryValueCount() -> size_t;
 
  private:
   template <typename Runnable>
   auto RunTask(Runnable runnable,
-               Callback callback,
+
                uint64_t callback_id) -> uint64_t;
 
+  Callback callback_;
   std::shared_ptr<IsolateManager> isolate_manager_;
   std::shared_ptr<IsolateMemoryMonitor> isolate_memory_monitor_;
   std::shared_ptr<BinaryValueFactory> bv_factory_;

--- a/src/v8_py_frontend/context_factory.cc
+++ b/src/v8_py_frontend/context_factory.cc
@@ -8,6 +8,7 @@
 #include <mutex>
 #include <string>
 #include <utility>
+#include "callback.h"
 #include "context.h"
 #include "gsl_stub.h"
 
@@ -29,10 +30,10 @@ auto ContextFactory::Get() -> ContextFactory* {
   return singleton_;
 }
 
-auto ContextFactory::MakeContext() -> uint64_t {
+auto ContextFactory::MakeContext(Callback callback) -> uint64_t {
   // Actually create the context before we get the lock, in case the program is
   // making Contexts in other threads:
-  auto context = std::make_shared<Context>(current_platform_.get());
+  auto context = std::make_shared<Context>(current_platform_.get(), callback);
 
   const std::lock_guard<std::mutex> lock(mutex_);
   const uint64_t context_id = next_context_id_++;

--- a/src/v8_py_frontend/context_factory.h
+++ b/src/v8_py_frontend/context_factory.h
@@ -9,6 +9,7 @@
 #include <mutex>
 #include <string>
 #include <unordered_map>
+#include "callback.h"
 #include "context.h"
 #include "gsl_stub.h"
 
@@ -21,7 +22,7 @@ class ContextFactory {
                    const std::filesystem::path& snapshot_path);
 
   static auto Get() -> ContextFactory*;
-  auto MakeContext() -> uint64_t;
+  auto MakeContext(Callback callback) -> uint64_t;
   auto GetContext(uint64_t context_id) -> std::shared_ptr<Context>;
   void FreeContext(uint64_t context_id);
   auto Count() -> size_t;

--- a/src/v8_py_frontend/exports.cc
+++ b/src/v8_py_frontend/exports.cc
@@ -28,13 +28,12 @@ auto GetContext(uint64_t context_id) -> std::shared_ptr<MiniRacer::Context> {
 
 LIB_EXPORT auto mr_eval(uint64_t context_id,
                         MiniRacer::BinaryValueHandle* code_handle,
-                        MiniRacer::Callback callback,
                         uint64_t callback_id) -> uint64_t {
   auto context = GetContext(context_id);
   if (!context) {
     return 0;
   }
-  return context->Eval(code_handle, callback, callback_id);
+  return context->Eval(code_handle, callback_id);
 }
 
 LIB_EXPORT void mr_init_v8(const char* v8_flags,
@@ -43,12 +42,12 @@ LIB_EXPORT void mr_init_v8(const char* v8_flags,
   MiniRacer::ContextFactory::Init(v8_flags, icu_path, snapshot_path);
 }
 
-LIB_EXPORT auto mr_init_context() -> uint64_t {
+LIB_EXPORT auto mr_init_context(MiniRacer::Callback callback) -> uint64_t {
   auto* context_factory = MiniRacer::ContextFactory::Get();
   if (context_factory == nullptr) {
     return 0;
   }
-  return context_factory->MakeContext();
+  return context_factory->MakeContext(callback);
 }
 
 LIB_EXPORT void mr_free_context(uint64_t context_id) {
@@ -119,13 +118,12 @@ LIB_EXPORT void mr_cancel_task(uint64_t context_id, uint64_t task_id) {
 }
 
 LIB_EXPORT auto mr_heap_stats(uint64_t context_id,
-                              MiniRacer::Callback callback,
                               uint64_t callback_id) -> uint64_t {
   auto context = GetContext(context_id);
   if (!context) {
     return 0;
   }
-  return context->HeapStats(callback, callback_id);
+  return context->HeapStats(callback_id);
 }
 
 LIB_EXPORT void mr_set_hard_memory_limit(uint64_t context_id, size_t limit) {
@@ -179,13 +177,12 @@ LIB_EXPORT auto mr_v8_is_using_sandbox() -> bool {
 LIB_EXPORT auto mr_attach_promise_then(
     uint64_t context_id,
     MiniRacer::BinaryValueHandle* promise_handle,
-    MiniRacer::Callback callback,
     uint64_t callback_id) -> MiniRacer::BinaryValueHandle* {
   auto context = GetContext(context_id);
   if (!context) {
     return nullptr;
   }
-  return context->AttachPromiseThen(promise_handle, callback, callback_id);
+  return context->AttachPromiseThen(promise_handle, callback_id);
 }
 
 LIB_EXPORT auto mr_get_identity_hash(uint64_t context_id,
@@ -260,24 +257,22 @@ LIB_EXPORT auto mr_call_function(uint64_t context_id,
                                  MiniRacer::BinaryValueHandle* func_handle,
                                  MiniRacer::BinaryValueHandle* this_handle,
                                  MiniRacer::BinaryValueHandle* argv_handle,
-                                 MiniRacer::Callback callback,
                                  uint64_t callback_id) -> uint64_t {
   auto context = GetContext(context_id);
   if (!context) {
     return 0;
   }
-  return context->CallFunction(func_handle, this_handle, argv_handle, callback,
+  return context->CallFunction(func_handle, this_handle, argv_handle,
                                callback_id);
 }
 
 LIB_EXPORT auto mr_heap_snapshot(uint64_t context_id,
-                                 MiniRacer::Callback callback,
                                  uint64_t callback_id) -> uint64_t {
   auto context = GetContext(context_id);
   if (!context) {
     return 0;
   }
-  return context->HeapSnapshot(callback, callback_id);
+  return context->HeapSnapshot(callback_id);
 }
 
 LIB_EXPORT auto mr_value_count(uint64_t context_id) -> size_t {

--- a/src/v8_py_frontend/promise_attacher.cc
+++ b/src/v8_py_frontend/promise_attacher.cc
@@ -17,13 +17,15 @@
 
 namespace MiniRacer {
 
-PromiseAttacher::PromiseAttacher(std::shared_ptr<ContextHolder> context,
+PromiseAttacher::PromiseAttacher(Callback callback,
+                                 std::shared_ptr<ContextHolder> context,
                                  std::shared_ptr<BinaryValueFactory> bv_factory)
-    : context_(std::move(context)), bv_factory_(std::move(bv_factory)) {}
+    : callback_(callback),
+      context_(std::move(context)),
+      bv_factory_(std::move(bv_factory)) {}
 
 auto PromiseAttacher::AttachPromiseThen(v8::Isolate* isolate,
                                         BinaryValue* promise_ptr,
-                                        Callback callback,
                                         uint64_t callback_id)
     -> BinaryValue::Ptr {
   const v8::Isolate::Scope isolate_scope(isolate);
@@ -42,7 +44,7 @@ auto PromiseAttacher::AttachPromiseThen(v8::Isolate* isolate,
 
   // NOLINTNEXTLINE(cppcoreguidelines-owning-memory)
   auto* completion_handler =
-      new PromiseCompletionHandler(bv_factory_, callback, callback_id);
+      new PromiseCompletionHandler(bv_factory_, callback_, callback_id);
   const v8::Local<v8::External> edata =
       v8::External::New(isolate, completion_handler);
 

--- a/src/v8_py_frontend/promise_attacher.h
+++ b/src/v8_py_frontend/promise_attacher.h
@@ -15,15 +15,16 @@ namespace MiniRacer {
 
 class PromiseAttacher {
  public:
-  PromiseAttacher(std::shared_ptr<ContextHolder> context,
+  PromiseAttacher(Callback callback,
+                  std::shared_ptr<ContextHolder> context,
                   std::shared_ptr<BinaryValueFactory> bv_factory);
 
   auto AttachPromiseThen(v8::Isolate* isolate,
                          BinaryValue* promise_ptr,
-                         Callback callback,
                          uint64_t callback_id) -> BinaryValue::Ptr;
 
  private:
+  Callback callback_;
   std::shared_ptr<ContextHolder> context_;
   std::shared_ptr<BinaryValueFactory> bv_factory_;
 };


### PR DESCRIPTION
We were passing the same callback function pointer from Python to C++ over and over.

This moves to just passing the callback function pointer once during Context initialization. This makes it a bit simpler and easier to understand (and document!) the object lifecycle requirements.