### PR TITLE
Fix advertised RHEL version

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ PyMiniRacer is distributed using [wheels](https://pythonwheels.com/) on
 | Windows ≥ 10                    | ✓      | ✖       |
 | Ubuntu ≥ 20.04                  | ✓      | ✓       |
 | Debian ≥ 11                     | ✓      | ✓       |
-| RHEL ≥ 8                        | ✓      | ✓       |
+| RHEL ≥ 9                        | ✓      | ✓       |
 | other Linuxes with glibc ≥ 2.31 | ✓      | ✓       |
 | Alpine ≥ 3.19                   | ✓      | ✓       |
 | other Linux with musl ≥ 1.2     | ✓      | ✓       |


### PR DESCRIPTION
I realized I wrote this wrong... PyMiniRacer currently requires glibc 2.31 on glibc Linux (because it lets V8 use its download of the Debian bullseye sysroot). RHEL and Rocky 8 is still on glibc 2.28, whereas RHEL and Rocky 9 are on glibc 2.34.

(Verified it works on Rocky 9 and fails on Rocky 8 by pulling and running the latest PyMiniRacer wheel from PyPI on an official Rocky container.)