### PR TITLE
Make callbacks actually reusable

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -46,11 +46,7 @@ repos:
         # lvmlibc-* is intended for the llvm project itself
         # llvm-header-guard is likewise hard-coded for the llvm project itself
         # llvm-include-order fights clang-format --style=Chromium
-        # fuchsia-default-arguments-calls seems counter to code maintainability
-        # outside of a monorepo
-        # same for fuchsia-default-arguments-declarations
-        # fuchsia-trailing-return is counter to another cpp modernization rule
-        # fuchsia-overloaded-operator is incompatible with... making functors?
+        # fuchsia has some odd opinions, so disable it globally.
         # altera-* is designed for FPGAs and gives weird performance advice.
         # we aren't using Google's absl lib, so disable its suggestions.
         - >-
@@ -58,10 +54,7 @@ repos:
           -llvmlibc-*,
           -llvm-header-guard,
           -llvm-include-order,
-          -fuchsia-default-arguments-calls,
-          -fuchsia-default-arguments-declarations,
-          -fuchsia-trailing-return,
-          -fuchsia-overloaded-operator,
+          -fuchsia-*,
           -altera-*,
           -abseil-*
         - -warnings-as-errors=*

--- a/src/v8_py_frontend/js_callback_maker.cc
+++ b/src/v8_py_frontend/js_callback_maker.cc
@@ -1,13 +1,15 @@
 #include "js_callback_maker.h"
 #include <v8-container.h>
 #include <v8-context.h>
-#include <v8-external.h>
 #include <v8-function-callback.h>
 #include <v8-function.h>
 #include <v8-local-handle.h>
 #include <v8-persistent-handle.h>
+#include <v8-primitive.h>
+#include <array>
 #include <cstdint>
 #include <memory>
+#include <mutex>
 #include <utility>
 #include "binary_value.h"
 #include "callback.h"
@@ -15,54 +17,163 @@
 
 namespace MiniRacer {
 
-JSCallbackMaker::JSCallbackMaker(std::shared_ptr<ContextHolder> context,
-                                 std::shared_ptr<BinaryValueFactory> bv_factory,
-                                 Callback callback)
-    : context_(std::move(context)),
-      bv_factory_(std::move(bv_factory)),
-      callback_(callback) {}
+JSCallbackCallerRegistry JSCallbackCallerRegistry::singleton_;
+
+JSCallbackCaller::JSCallbackCaller(
+    std::shared_ptr<BinaryValueFactory> bv_factory,
+    Callback callback)
+    : bv_factory_(std::move(bv_factory)), callback_(callback) {}
+
+void JSCallbackCaller::DoCallback(v8::Local<v8::Context> context,
+                                  uint64_t callback_id,
+                                  v8::Local<v8::Array> args) {
+  const BinaryValue::Ptr args_ptr = bv_factory_->New(context, args);
+  callback_(callback_id, args_ptr->GetHandle());
+}
+
+auto JSCallbackCallerRegistry::Get() -> JSCallbackCallerRegistry* {
+  return &singleton_;
+}
+
+auto JSCallbackCallerRegistry::Register(
+    std::shared_ptr<BinaryValueFactory> bv_factory,
+    Callback callback) -> uint64_t {
+  auto context_caller =
+      std::make_shared<JSCallbackCaller>(std::move(bv_factory), callback);
+  const std::lock_guard<std::mutex> lock(mutex_);
+  const uint64_t callback_caller_id = next_id_++;
+  callback_callers_[callback_caller_id] = context_caller;
+  return callback_caller_id;
+}
+
+void JSCallbackCallerRegistry::Unregister(uint64_t callback_caller_id) {
+  const std::lock_guard<std::mutex> lock(mutex_);
+  callback_callers_.erase(callback_caller_id);
+}
+
+auto JSCallbackCallerRegistry::Get(uint64_t callback_caller_id)
+    -> std::shared_ptr<JSCallbackCaller> {
+  const std::lock_guard<std::mutex> lock(mutex_);
+  auto iter = callback_callers_.find(callback_caller_id);
+  if (iter == callback_callers_.end()) {
+    return {};
+  }
+  return iter->second;
+}
+
+JSCallbackCallerHolder::JSCallbackCallerHolder(
+    std::shared_ptr<BinaryValueFactory> bv_factory,
+    Callback callback)
+    : callback_caller_id_(
+          JSCallbackCallerRegistry::Get()->Register(std::move(bv_factory),
+                                                    callback)) {}
+
+JSCallbackCallerHolder::~JSCallbackCallerHolder() {
+  JSCallbackCallerRegistry::Get()->Unregister(callback_caller_id_);
+}
+
+auto JSCallbackCallerHolder::Get() const -> uint64_t {
+  return callback_caller_id_;
+}
+
+JSCallbackMaker::JSCallbackMaker(
+    std::shared_ptr<ContextHolder> context_holder,
+    const std::shared_ptr<BinaryValueFactory>& bv_factory,
+    Callback callback)
+    : context_holder_(std::move(context_holder)),
+      bv_factory_(bv_factory),
+      callback_caller_holder_(bv_factory, callback) {}
 
 auto JSCallbackMaker::MakeJSCallback(v8::Isolate* isolate,
                                      uint64_t callback_id) -> BinaryValue::Ptr {
   const v8::Isolate::Scope isolate_scope(isolate);
   const v8::HandleScope handle_scope(isolate);
-  const v8::Local<v8::Context> local_context = context_->Get()->Get(isolate);
-  const v8::Context::Scope context_scope(local_context);
+  const v8::Local<v8::Context> context = context_holder_->Get()->Get(isolate);
+  const v8::Context::Scope context_scope(context);
 
-  // NOLINTNEXTLINE(cppcoreguidelines-owning-memory)
-  auto* callback_handler =
-      new CallbackHandler(bv_factory_, callback_, callback_id);
-  const v8::Local<v8::External> edata =
-      v8::External::New(isolate, callback_handler);
+  // We create a JS Array containing:
+  // {a BigInt indicating the callback caller ID, a BigInt indicating the
+  // callback ID}
+  // ... And stuff it into the callback, so we can understand the context when
+  // we're called back.
+  // We do this instead of embedding pointers to C++ objects in the objects
+  // (using v8::External) so that we can control object teardown. In this model,
+  // we tear down C++ objects when the MiniRacer::Context is torn down using
+  // std::shared_ptr to track dependencies, and if a callback executes after
+  // the underlying callback caller is torn down, that callback is safely
+  // ignored.
+  const v8::Local<v8::BigInt> callback_caller_id_bigint =
+      v8::BigInt::NewFromUnsigned(isolate, callback_caller_holder_.Get());
+  const v8::Local<v8::BigInt> callback_id_bigint =
+      v8::BigInt::NewFromUnsigned(isolate, callback_id);
+  std::array<v8::Local<v8::Value>, 2> data_elements = {
+      callback_caller_id_bigint, callback_id_bigint};
+
+  const v8::Local<v8::Array> data =
+      v8::Array::New(isolate, data_elements.data(), data_elements.size());
 
   const v8::Local<v8::Function> func =
-      v8::Function::New(local_context, &CallbackHandler::OnCalledStatic, edata)
+      v8::Function::New(context, &JSCallbackMaker::OnCalledStatic, data)
           .ToLocalChecked();
 
-  return bv_factory_->New(local_context, func);
+  return bv_factory_->New(context, func);
 }
 
-CallbackHandler::CallbackHandler(std::shared_ptr<BinaryValueFactory> bv_factory,
-                                 Callback callback,
-                                 uint64_t callback_id)
-    : bv_factory_(std::move(bv_factory)),
-      callback_(callback),
-      callback_id_(callback_id) {}
-
-void CallbackHandler::OnCalledStatic(
+void JSCallbackMaker::OnCalledStatic(
     const v8::FunctionCallbackInfo<v8::Value>& info) {
-  std::unique_ptr<CallbackHandler> callback_handler(
-      static_cast<CallbackHandler*>(info.Data().As<v8::External>()->Value()));
-
-  callback_handler->OnCalled(info.GetIsolate(), info);
-}
-
-void CallbackHandler::OnCalled(
-    v8::Isolate* isolate,
-    const v8::FunctionCallbackInfo<v8::Value>& info) {
+  v8::Isolate* isolate = info.GetIsolate();
   const v8::HandleScope scope(isolate);
   const v8::Local<v8::Context> context = isolate->GetCurrentContext();
   const v8::Context::Scope context_scope(context);
+
+  const v8::Local<v8::Value> data_value = info.Data();
+
+  if (!data_value->IsArray()) {
+    return;
+  }
+  const v8::Local<v8::Array> data_array = data_value.As<v8::Array>();
+
+  if (data_array->Length() != 2) {
+    return;
+  }
+  const v8::MaybeLocal<v8::Value> callback_caller_id_value_maybe =
+      data_array->Get(context, 0);
+  const v8::MaybeLocal<v8::Value> callback_id_value_maybe =
+      data_array->Get(context, 1);
+
+  v8::Local<v8::Value> callback_caller_id_value;
+  if (!callback_caller_id_value_maybe.ToLocal(&callback_caller_id_value)) {
+    return;
+  }
+
+  if (!callback_caller_id_value->IsBigInt()) {
+    return;
+  }
+  const v8::Local<v8::BigInt> callback_caller_id_bigint =
+      callback_caller_id_value.As<v8::BigInt>();
+
+  bool lossless = false;
+  const uint64_t callback_caller_id =
+      callback_caller_id_bigint->Uint64Value(&lossless);
+  if (!lossless) {
+    return;
+  }
+
+  v8::Local<v8::Value> callback_id_value;
+  if (!callback_id_value_maybe.ToLocal(&callback_id_value)) {
+    return;
+  }
+
+  if (!callback_id_value->IsBigInt()) {
+    return;
+  }
+  const v8::Local<v8::BigInt> callback_id_bigint =
+      callback_id_value.As<v8::BigInt>();
+
+  const uint64_t callback_id = callback_id_bigint->Uint64Value(&lossless);
+  if (!lossless) {
+    return;
+  }
 
   int idx = 0;
   const v8::Local<v8::Array> args =
@@ -70,9 +181,13 @@ void CallbackHandler::OnCalled(
         return info[idx++];
       }).ToLocalChecked();
 
-  const BinaryValue::Ptr args_ptr = bv_factory_->New(context, args);
+  const std::shared_ptr<JSCallbackCaller> callback_caller =
+      JSCallbackCallerRegistry::Get()->Get(callback_caller_id);
+  if (!callback_caller) {
+    return;
+  }
 
-  callback_(callback_id_, args_ptr->GetHandle());
+  callback_caller->DoCallback(context, callback_id, args);
 }
 
 }  // end namespace MiniRacer

--- a/src/v8_py_frontend/js_callback_maker.h
+++ b/src/v8_py_frontend/js_callback_maker.h
@@ -1,49 +1,93 @@
 #ifndef INCLUDE_MINI_RACER_JS_CALLBACK_MAKER_H
 #define INCLUDE_MINI_RACER_JS_CALLBACK_MAKER_H
 
+#include <v8-container.h>
 #include <v8-context.h>
 #include <v8-function-callback.h>
 #include <v8-isolate.h>
 #include <v8-persistent-handle.h>
 #include <cstdint>
 #include <memory>
+#include <mutex>
+#include <unordered_map>
 #include "binary_value.h"
 #include "callback.h"
 #include "context_holder.h"
 
 namespace MiniRacer {
 
+/** A callback caller contains the a bundle of items needed to successfully
+ * handle a callback from JS. This is affine to a single MiniRacer::Context (and
+ * so multiple callbacks can share a context).
+ */
+class JSCallbackCaller {
+ public:
+  JSCallbackCaller(std::shared_ptr<BinaryValueFactory> bv_factory,
+                   Callback callback);
+
+  void DoCallback(v8::Local<v8::Context> context,
+                  uint64_t callback_id,
+                  v8::Local<v8::Array> args);
+
+ private:
+  std::shared_ptr<BinaryValueFactory> bv_factory_;
+  Callback callback_;
+};
+
+class JSCallbackCallerRegistry {
+ public:
+  static auto Get() -> JSCallbackCallerRegistry*;
+
+  auto Register(std::shared_ptr<BinaryValueFactory> bv_factory,
+                Callback callback) -> uint64_t;
+  void Unregister(uint64_t callback_caller_id);
+
+  auto Get(uint64_t callback_caller_id) -> std::shared_ptr<JSCallbackCaller>;
+
+ private:
+  static JSCallbackCallerRegistry singleton_;
+  std::mutex mutex_;
+  uint64_t next_id_{0};
+  std::unordered_map<uint64_t, std::shared_ptr<JSCallbackCaller>>
+      callback_callers_;
+};
+
+class JSCallbackCallerHolder {
+ public:
+  JSCallbackCallerHolder(std::shared_ptr<BinaryValueFactory> bv_factory,
+                         Callback callback);
+
+  ~JSCallbackCallerHolder();
+
+  JSCallbackCallerHolder(const JSCallbackCallerHolder&) = delete;
+  auto operator=(const JSCallbackCallerHolder&) -> JSCallbackCallerHolder& =
+                                                       delete;
+  JSCallbackCallerHolder(JSCallbackCallerHolder&&) = delete;
+  auto operator=(JSCallbackCallerHolder&& other) -> JSCallbackCallerHolder& =
+                                                        delete;
+
+  [[nodiscard]] auto Get() const -> uint64_t;
+
+ private:
+  uint64_t callback_caller_id_;
+};
+
 /** Wraps a JS callback wrapped around the given C callback function pointer. */
 class JSCallbackMaker {
  public:
-  JSCallbackMaker(std::shared_ptr<ContextHolder> context,
-                  std::shared_ptr<BinaryValueFactory> bv_factory,
+  JSCallbackMaker(std::shared_ptr<ContextHolder> context_holder,
+                  const std::shared_ptr<BinaryValueFactory>& bv_factory,
                   Callback callback);
 
   auto MakeJSCallback(v8::Isolate* isolate,
                       uint64_t callback_id) -> BinaryValue::Ptr;
 
  private:
-  std::shared_ptr<ContextHolder> context_;
-  std::shared_ptr<BinaryValueFactory> bv_factory_;
-  Callback callback_;
-};
-
-class CallbackHandler {
- public:
-  CallbackHandler(std::shared_ptr<BinaryValueFactory> bv_factory,
-                  Callback callback_,
-                  uint64_t callback_id);
-
   static void OnCalledStatic(const v8::FunctionCallbackInfo<v8::Value>& info);
 
- private:
-  void OnCalled(v8::Isolate* isolate,
-                const v8::FunctionCallbackInfo<v8::Value>& info);
-
+  std::shared_ptr<ContextHolder> context_holder_;
   std::shared_ptr<BinaryValueFactory> bv_factory_;
-  Callback callback_;
-  uint64_t callback_id_;
+  JSCallbackCallerHolder callback_caller_holder_;
 };
 
 }  // namespace MiniRacer


### PR DESCRIPTION
https://github.com/bpcreech/PyMiniRacer/pull/46 was meant to make the on-the-fly callback system, currently only used by promises, generate callbacks which are reusable for more than one call.

That PR worked on the Python side, but I forgot about the `CallbackHandler` on the C++ side: it is destroyed after first use.

This PR removes `CallbackHandler`, baking the one thing it needed, the callback ID, into a JS object.