### PR TITLE
Generalize ID generation

### DIFF
--- a/src/v8_py_frontend/BUILD.gn
+++ b/src/v8_py_frontend/BUILD.gn
@@ -19,6 +19,7 @@ v8_shared_library("mini_racer") {
     "gsl_stub.h",
     "heap_reporter.h",
     "heap_reporter.cc",
+    "id_maker.h",
     "isolate_holder.h",
     "isolate_holder.cc",
     "isolate_manager.h",

--- a/src/v8_py_frontend/cancelable_task_runner.cc
+++ b/src/v8_py_frontend/cancelable_task_runner.cc
@@ -4,6 +4,7 @@
 #include <memory>
 #include <mutex>
 #include <utility>
+#include "id_maker.h"
 #include "isolate_manager.h"
 
 namespace MiniRacer {
@@ -45,52 +46,19 @@ auto CancelableTaskState::SetCompleteIfNotCanceled() -> bool {
 }
 
 CancelableTaskRunner::CancelableTaskRunner(
-    const std::shared_ptr<IsolateManager>& isolate_manager)
-    : isolate_manager_(isolate_manager),
-      task_registry_(
-          std::make_shared<CancelableTaskRegistry>(isolate_manager)) {}
+    std::shared_ptr<IsolateManager> isolate_manager)
+    : isolate_manager_(std::move(isolate_manager)),
+      task_id_maker_(std::make_shared<IdMaker<CancelableTaskState>>()) {}
 
 void CancelableTaskRunner::Cancel(uint64_t task_id) {
-  task_registry_->Cancel(task_id);
-}
-
-CancelableTaskRegistry::CancelableTaskRegistry(
-    std::shared_ptr<IsolateManager> isolate_manager)
-    : isolate_manager_(std::move(isolate_manager)), next_task_id_(1) {}
-
-auto CancelableTaskRegistry::Create(
-    std::shared_ptr<CancelableTaskState> task_state) -> uint64_t {
-  const std::lock_guard<std::mutex> lock(mutex_);
-  const uint64_t task_id = next_task_id_++;
-  tasks_[task_id] = std::move(task_state);
-  return task_id;
-}
-
-void CancelableTaskRegistry::Remove(uint64_t task_id) {
-  const std::lock_guard<std::mutex> lock(mutex_);
-  tasks_.erase(task_id);
-}
-
-void CancelableTaskRegistry::Cancel(uint64_t task_id) {
-  std::shared_ptr<CancelableTaskState> task_state;
-  {
-    const std::lock_guard<std::mutex> lock(mutex_);
-    auto iter = tasks_.find(task_id);
-    if (iter == tasks_.end()) {
-      return;
-    }
-    task_state = iter->second;
+  const std::shared_ptr<CancelableTaskState> task_state =
+      task_id_maker_->GetObject(task_id);
+  if (!task_state) {
+    // No such task found. This will commonly happen if a task is canceled
+    // after it has already completed.
+    return;
   }
   task_state->Cancel(isolate_manager_.get());
-}
-
-CancelableTaskRegistryRemover::CancelableTaskRegistryRemover(
-    uint64_t task_id,
-    std::shared_ptr<CancelableTaskRegistry> task_registry)
-    : task_id_(task_id), task_registry_(std::move(task_registry)) {}
-
-CancelableTaskRegistryRemover::~CancelableTaskRegistryRemover() {
-  task_registry_->Remove(task_id_);
 }
 
 }  // end namespace MiniRacer

--- a/src/v8_py_frontend/context_factory.h
+++ b/src/v8_py_frontend/context_factory.h
@@ -8,10 +8,10 @@
 #include <memory>
 #include <mutex>
 #include <string>
-#include <unordered_map>
 #include "callback.h"
 #include "context.h"
 #include "gsl_stub.h"
+#include "id_maker.h"
 
 namespace MiniRacer {
 
@@ -35,9 +35,7 @@ class ContextFactory {
   static std::once_flag init_flag_;
   static gsl::owner<ContextFactory*> singleton_;
   std::unique_ptr<v8::Platform> current_platform_;
-  std::mutex mutex_;
-  uint64_t next_context_id_;
-  std::unordered_map<uint64_t, std::shared_ptr<Context>> contexts_;
+  IdMaker<Context> contexts_;
 };
 
 }  // namespace MiniRacer

--- a/src/v8_py_frontend/id_maker.h
+++ b/src/v8_py_frontend/id_maker.h
@@ -1,0 +1,126 @@
+#ifndef INCLUDE_MINI_RACER_ID_MAKER_H
+#define INCLUDE_MINI_RACER_ID_MAKER_H
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <mutex>
+#include <unordered_map>
+#include <utility>
+
+namespace MiniRacer {
+
+/** Assigns uint64_t IDs to C++ objects.
+ *
+ * Assigning arbitrary numeric IDs to C++ objects is a common pattern in
+ * PyMiniRacer, because it provides a safe way to share references to objects
+ * with both Python and JavaScript. Neither Python nor JavaScript provides
+ * strong object lifecycle management guarantees (and V8 in particular seems
+ * hostile to the idea), so it's hard to trust the Python or JavaScript
+ * runtimes to tell us when they're actually done using a reference.
+ *
+ * Instead we create a numeric ID and hand that to Python and JavaScript. This
+ * way we can validate the ID when it's passed back to C++, more gracefully
+ * handling use-after-free errors, and providing a backing stop for garbage
+ * collection even if Python or JavaScript never sends a finalization signal.
+ */
+template <typename T>
+class IdMaker {
+ public:
+  auto MakeId(std::shared_ptr<T> object) -> uint64_t;
+  auto GetObject(uint64_t object_id) -> std::shared_ptr<T>;
+  void EraseId(uint64_t object_id);
+  auto CountIds() -> size_t;
+
+ private:
+  std::mutex mutex_;
+  uint64_t next_object_id_{1};
+  std::unordered_map<uint64_t, std::shared_ptr<T>> objects_;
+};
+
+/** Registers an ID for the given object, and then unregisters that ID upon
+ * destruction. */
+template <typename T>
+class IdHolder {
+ public:
+  IdHolder(std::shared_ptr<T> object, std::shared_ptr<IdMaker<T>> id_maker);
+  ~IdHolder();
+
+  IdHolder(const IdHolder&) = delete;
+  auto operator=(const IdHolder&) -> IdHolder& = delete;
+  IdHolder(IdHolder&&) = delete;
+  auto operator=(IdHolder&& other) -> IdHolder& = delete;
+
+  auto GetId() -> uint64_t;
+  auto GetObject() -> std::shared_ptr<T>;
+
+ private:
+  std::shared_ptr<IdMaker<T>> id_maker_;
+  uint64_t object_id_;
+};
+
+template <typename T>
+inline auto IdMaker<T>::MakeId(std::shared_ptr<T> object) -> uint64_t {
+  const std::lock_guard<std::mutex> lock(mutex_);
+  const uint64_t object_id = next_object_id_++;
+  objects_[object_id] = std::move(object);
+  return object_id;
+}
+
+template <typename T>
+inline auto IdMaker<T>::GetObject(uint64_t object_id) -> std::shared_ptr<T> {
+  const std::lock_guard<std::mutex> lock(mutex_);
+  auto iter = objects_.find(object_id);
+  if (iter == objects_.end()) {
+    return {};
+  }
+  return iter->second;
+}
+
+template <typename T>
+inline void IdMaker<T>::EraseId(uint64_t object_id) {
+  std::shared_ptr<T> object;
+  {
+    const std::lock_guard<std::mutex> lock(mutex_);
+    auto iter = objects_.find(object_id);
+    if (iter == objects_.end()) {
+      return;
+    }
+    object = std::move(iter->second);
+    objects_.erase(iter);
+  }
+  // We actually destruct the object here, outside of the mutex, so that other
+  // threads can continue to make, get, and erase object IDs.
+  // (Of course, other shared_ptr references to this object may also exist, and
+  // if so this object will be destructed at another time entirely.)
+}
+
+template <typename T>
+inline auto IdMaker<T>::CountIds() -> size_t {
+  const std::lock_guard<std::mutex> lock(mutex_);
+  return objects_.size();
+}
+
+template <typename T>
+inline IdHolder<T>::IdHolder(std::shared_ptr<T> object,
+                             std::shared_ptr<IdMaker<T>> id_maker)
+    : id_maker_(std::move(id_maker)), object_id_(id_maker_->MakeId(object)) {}
+
+template <typename T>
+inline IdHolder<T>::~IdHolder() {
+  id_maker_->EraseId(object_id_);
+}
+
+template <typename T>
+inline auto IdHolder<T>::GetId() -> uint64_t {
+  return object_id_;
+}
+
+template <typename T>
+inline auto IdHolder<T>::GetObject() -> std::shared_ptr<T> {
+  return id_maker_->GetObject(object_id_);
+}
+
+}  // end namespace MiniRacer
+
+#endif  // INCLUDE_MINI_RACER_ID_MAKER_H


### PR DESCRIPTION
This takes a recurring pattern of turning C++ objects into `uint64_t`s, and generalizing it, using it in 3 places.

We could in theory use this in `BinaryValueFactory` too, but that would be a bit more work as it would change the Python/C++ interface.