### PR TITLE
Separate out rememberance of BinaryValues

### DIFF
--- a/src/v8_py_frontend/callback.h
+++ b/src/v8_py_frontend/callback.h
@@ -2,11 +2,15 @@
 #define INCLUDE_MINI_RACER_CALLBACK_H
 
 #include <cstdint>
+#include <functional>
 #include "binary_value.h"
 
 namespace MiniRacer {
 
 using Callback = void (*)(uint64_t, BinaryValueHandle*);
+
+using RememberValueAndCallback =
+    std::function<void(uint64_t, BinaryValue::Ptr)>;
 
 }  // end namespace MiniRacer
 

--- a/src/v8_py_frontend/context.cc
+++ b/src/v8_py_frontend/context.cc
@@ -22,11 +22,16 @@
 namespace MiniRacer {
 
 Context::Context(v8::Platform* platform, Callback callback)
-    : callback_(callback),
-      isolate_manager_(std::make_shared<IsolateManager>(platform)),
+    : isolate_manager_(std::make_shared<IsolateManager>(platform)),
       isolate_memory_monitor_(
           std::make_shared<IsolateMemoryMonitor>(isolate_manager_)),
       bv_factory_(std::make_shared<BinaryValueFactory>(isolate_manager_)),
+      bv_registry_(std::make_shared<BinaryValueRegistry>()),
+      callback_(
+          [bv_registry = bv_registry_,
+           callback = callback](uint64_t callback_id, BinaryValue::Ptr val) {
+            callback(callback_id, bv_registry->Remember(std::move(val)));
+          }),
       context_holder_(std::make_shared<ContextHolder>(isolate_manager_)),
       js_callback_maker_(std::make_shared<JSCallbackMaker>(context_holder_,
                                                            bv_factory_,
@@ -41,12 +46,11 @@ Context::Context(v8::Platform* platform, Callback callback)
           std::make_shared<CancelableTaskRunner>(isolate_manager_)) {}
 
 auto Context::MakeJSCallback(uint64_t callback_id) -> BinaryValueHandle* {
-  return isolate_manager_
-      ->RunAndAwait([js_callback_maker = js_callback_maker_,
-                     callback_id](v8::Isolate* isolate) {
+  return bv_registry_->Remember(
+      isolate_manager_->RunAndAwait([js_callback_maker = js_callback_maker_,
+                                     callback_id](v8::Isolate* isolate) {
         return js_callback_maker->MakeJSCallback(isolate, callback_id);
-      })
-      ->GetHandle();
+      }));
 }
 
 template <typename Runnable>
@@ -57,34 +61,65 @@ auto Context::RunTask(Runnable runnable, uint64_t callback_id) -> uint64_t {
       /*runnable=*/
       std::move(runnable),
       /*on_completed=*/
-      [callback = callback_, callback_id](const BinaryValue::Ptr& val) {
-        callback(callback_id, val->GetHandle());
-      },
+      [callback = callback_, bv_registry = bv_registry_, callback_id](
+          const BinaryValue::Ptr& val) { callback(callback_id, val); },
       /*on_canceled=*/
-      [callback = callback_, callback_id,
-       bv_factory = bv_factory_](const BinaryValue::Ptr& val) {
-        if (val) {
-          // Ignore the produced value, if any:
-          bv_factory->Free(val->GetHandle());
-        }
-
+      [callback = callback_, callback_id, bv_factory = bv_factory_,
+       bv_registry = bv_registry_](const BinaryValue::Ptr& /*val*/) {
         auto err =
             bv_factory->New("execution terminated", type_terminated_exception);
-        callback(callback_id, err->GetHandle());
+        callback(callback_id, err);
       });
+}
+
+auto Context::MakeHandleConverter(BinaryValueHandle* handle,
+                                  const char* err_msg) -> ValueHandleConverter {
+  return {bv_factory_, bv_registry_, handle, err_msg};
+}
+
+ValueHandleConverter::ValueHandleConverter(
+    std::shared_ptr<BinaryValueFactory> bv_factory,
+    const std::shared_ptr<BinaryValueRegistry>& bv_registry,
+    BinaryValueHandle* handle,
+    const char* err_msg)
+    : bv_registry_(bv_registry),
+      ptr_(bv_registry->FromHandle(handle)),
+      err_([&bv_factory, err_msg, this]() {
+        if (ptr_) {
+          return BinaryValue::Ptr();
+        }
+
+        return bv_factory->New(err_msg, type_value_exception);
+      }()) {}
+
+ValueHandleConverter::operator bool() const {
+  return static_cast<bool>(ptr_);
+}
+
+auto ValueHandleConverter::GetErrorPtr() -> BinaryValue::Ptr {
+  return err_;
+}
+
+auto ValueHandleConverter::GetErrorHandle() -> BinaryValueHandle* {
+  return bv_registry_->Remember(err_);
+}
+
+auto ValueHandleConverter::GetPtr() -> BinaryValue::Ptr {
+  return ptr_;
 }
 
 auto Context::Eval(BinaryValueHandle* code_handle,
                    uint64_t callback_id) -> uint64_t {
-  auto code_ptr = bv_factory_->FromHandle(code_handle);
-  if (!code_ptr) {
-    auto err = bv_factory_->New("Bad handle: code", type_value_exception);
-    return RunTask([err](v8::Isolate* /*isolate*/) { return err; },
-                   callback_id);
+  auto code_hc = MakeHandleConverter(code_handle, "Bad handle: code");
+  if (!code_hc) {
+    return RunTask(
+        [err = code_hc.GetErrorPtr()](v8::Isolate* /*isolate*/) { return err; },
+        callback_id);
   }
 
   return RunTask(
-      [code_ptr, code_evaluator = code_evaluator_](v8::Isolate* isolate) {
+      [code_ptr = code_hc.GetPtr(),
+       code_evaluator = code_evaluator_](v8::Isolate* isolate) {
         return code_evaluator->Eval(isolate, code_ptr.get());
       },
       callback_id);
@@ -112,111 +147,98 @@ auto Context::HeapStats(uint64_t callback_id) -> uint64_t {
 
 auto Context::GetIdentityHash(BinaryValueHandle* obj_handle)
     -> BinaryValueHandle* {
-  auto obj_ptr = bv_factory_->FromHandle(obj_handle);
-  if (!obj_ptr) {
-    return bv_factory_->New("Bad handle: obj", type_value_exception)
-        ->GetHandle();
+  auto obj_hc = MakeHandleConverter(obj_handle, "Bad handle: obj");
+  if (!obj_hc) {
+    return obj_hc.GetErrorHandle();
   }
 
-  return isolate_manager_
-      ->RunAndAwait([object_manipulator = object_manipulator_,
-                     obj_ptr](v8::Isolate* isolate) {
+  return bv_registry_->Remember(isolate_manager_->RunAndAwait(
+      [object_manipulator = object_manipulator_,
+       obj_ptr = obj_hc.GetPtr()](v8::Isolate* isolate) {
         return object_manipulator->GetIdentityHash(isolate, obj_ptr.get());
-      })
-      ->GetHandle();
+      }));
 }
 
 auto Context::GetOwnPropertyNames(BinaryValueHandle* obj_handle)
     -> BinaryValueHandle* {
-  auto obj_ptr = bv_factory_->FromHandle(obj_handle);
-  if (!obj_ptr) {
-    return bv_factory_->New("Bad handle: obj", type_value_exception)
-        ->GetHandle();
+  auto obj_hc = MakeHandleConverter(obj_handle, "Bad handle: obj");
+  if (!obj_hc) {
+    return obj_hc.GetErrorHandle();
   }
 
-  return isolate_manager_
-      ->RunAndAwait([object_manipulator = object_manipulator_,
-                     obj_ptr](v8::Isolate* isolate) {
+  return bv_registry_->Remember(isolate_manager_->RunAndAwait(
+      [object_manipulator = object_manipulator_,
+       obj_ptr = obj_hc.GetPtr()](v8::Isolate* isolate) {
         return object_manipulator->GetOwnPropertyNames(isolate, obj_ptr.get());
-      })
-      ->GetHandle();
+      }));
 }
 
 auto Context::GetObjectItem(BinaryValueHandle* obj_handle,
                             BinaryValueHandle* key_handle)
     -> BinaryValueHandle* {
-  auto obj_ptr = bv_factory_->FromHandle(obj_handle);
-  if (!obj_ptr) {
-    return bv_factory_->New("Bad handle: obj", type_value_exception)
-        ->GetHandle();
+  auto obj_hc = MakeHandleConverter(obj_handle, "Bad handle: obj");
+  if (!obj_hc) {
+    return obj_hc.GetErrorHandle();
   }
 
-  auto key_ptr = bv_factory_->FromHandle(key_handle);
-  if (!key_ptr) {
-    return bv_factory_->New("Bad handle: key", type_value_exception)
-        ->GetHandle();
+  auto key_hc = MakeHandleConverter(key_handle, "Bad handle: key");
+  if (!key_hc) {
+    return key_hc.GetErrorHandle();
   }
 
-  return isolate_manager_
-      ->RunAndAwait([object_manipulator = object_manipulator_, obj_ptr,
-                     key_ptr](v8::Isolate* isolate) mutable {
+  return bv_registry_->Remember(isolate_manager_->RunAndAwait(
+      [object_manipulator = object_manipulator_, obj_ptr = obj_hc.GetPtr(),
+       key_ptr = key_hc.GetPtr()](v8::Isolate* isolate) mutable {
         return object_manipulator->Get(isolate, obj_ptr.get(), key_ptr.get());
-      })
-      ->GetHandle();
+      }));
 }
 
 auto Context::SetObjectItem(BinaryValueHandle* obj_handle,
                             BinaryValueHandle* key_handle,
                             BinaryValueHandle* val_handle)
     -> BinaryValueHandle* {
-  auto obj_ptr = bv_factory_->FromHandle(obj_handle);
-  if (!obj_ptr) {
-    return bv_factory_->New("Bad handle: obj", type_value_exception)
-        ->GetHandle();
+  auto obj_hc = MakeHandleConverter(obj_handle, "Bad handle: obj");
+  if (!obj_hc) {
+    return obj_hc.GetErrorHandle();
   }
 
-  auto key_ptr = bv_factory_->FromHandle(key_handle);
-  if (!key_ptr) {
-    return bv_factory_->New("Bad handle: key", type_value_exception)
-        ->GetHandle();
+  auto key_hc = MakeHandleConverter(key_handle, "Bad handle: key");
+  if (!key_hc) {
+    return key_hc.GetErrorHandle();
   }
 
-  auto val_ptr = bv_factory_->FromHandle(val_handle);
-  if (!val_ptr) {
-    return bv_factory_->New("Bad handle: val", type_value_exception)
-        ->GetHandle();
+  auto val_hc = MakeHandleConverter(val_handle, "Bad handle: val");
+  if (!val_hc) {
+    return val_hc.GetErrorHandle();
   }
 
-  return isolate_manager_
-      ->RunAndAwait([object_manipulator = object_manipulator_, obj_ptr, key_ptr,
-                     val_ptr](v8::Isolate* isolate) mutable {
+  return bv_registry_->Remember(isolate_manager_->RunAndAwait(
+      [object_manipulator = object_manipulator_, obj_ptr = obj_hc.GetPtr(),
+       key_ptr = key_hc.GetPtr(),
+       val_ptr = val_hc.GetPtr()](v8::Isolate* isolate) mutable {
         return object_manipulator->Set(isolate, obj_ptr.get(), key_ptr.get(),
                                        val_ptr.get());
-      })
-      ->GetHandle();
+      }));
 }
 
 auto Context::DelObjectItem(BinaryValueHandle* obj_handle,
                             BinaryValueHandle* key_handle)
     -> BinaryValueHandle* {
-  auto obj_ptr = bv_factory_->FromHandle(obj_handle);
-  if (!obj_ptr) {
-    return bv_factory_->New("Bad handle: obj", type_value_exception)
-        ->GetHandle();
+  auto obj_hc = MakeHandleConverter(obj_handle, "Bad handle: obj");
+  if (!obj_hc) {
+    return obj_hc.GetErrorHandle();
   }
 
-  auto key_ptr = bv_factory_->FromHandle(key_handle);
-  if (!key_ptr) {
-    return bv_factory_->New("Bad handle: key", type_value_exception)
-        ->GetHandle();
+  auto key_hc = MakeHandleConverter(key_handle, "Bad handle: key");
+  if (!key_hc) {
+    return key_hc.GetErrorHandle();
   }
 
-  return isolate_manager_
-      ->RunAndAwait([object_manipulator = object_manipulator_, obj_ptr,
-                     key_ptr](v8::Isolate* isolate) mutable {
+  return bv_registry_->Remember(isolate_manager_->RunAndAwait(
+      [object_manipulator = object_manipulator_, obj_ptr = obj_hc.GetPtr(),
+       key_ptr = key_hc.GetPtr()](v8::Isolate* isolate) mutable {
         return object_manipulator->Del(isolate, obj_ptr.get(), key_ptr.get());
-      })
-      ->GetHandle();
+      }));
 }
 
 auto Context::SpliceArray(BinaryValueHandle* obj_handle,
@@ -224,62 +246,62 @@ auto Context::SpliceArray(BinaryValueHandle* obj_handle,
                           int32_t delete_count,
                           BinaryValueHandle* new_val_handle)
     -> BinaryValueHandle* {
-  auto obj_ptr = bv_factory_->FromHandle(obj_handle);
-  if (!obj_ptr) {
-    return bv_factory_->New("Bad handle: obj", type_value_exception)
-        ->GetHandle();
+  auto obj_hc = MakeHandleConverter(obj_handle, "Bad handle: obj");
+  if (!obj_hc) {
+    return obj_hc.GetErrorHandle();
   }
 
   BinaryValue::Ptr new_val_ptr;
   if (new_val_handle != nullptr) {
-    new_val_ptr = bv_factory_->FromHandle(new_val_handle);
-    if (!new_val_ptr) {
-      return bv_factory_->New("Bad handle: new_val", type_value_exception)
-          ->GetHandle();
+    auto new_val_hc =
+        MakeHandleConverter(new_val_handle, "Bad handle: new_val");
+    if (!new_val_hc) {
+      return new_val_hc.GetErrorHandle();
     }
+    new_val_ptr = new_val_hc.GetPtr();
   }
 
-  return isolate_manager_
-      ->RunAndAwait([object_manipulator = object_manipulator_, obj_ptr, start,
-                     delete_count, new_val_ptr](v8::Isolate* isolate) {
+  return bv_registry_->Remember(isolate_manager_->RunAndAwait(
+      [object_manipulator = object_manipulator_, obj_ptr = obj_hc.GetPtr(),
+       start, delete_count, new_val_ptr](v8::Isolate* isolate) {
         return object_manipulator->Splice(isolate, obj_ptr.get(), start,
                                           delete_count, new_val_ptr.get());
-      })
-      ->GetHandle();
+      }));
 }
 
 void Context::FreeBinaryValue(BinaryValueHandle* val) {
-  bv_factory_->Free(val);
+  bv_registry_->Forget(val);
 }
 
 auto Context::CallFunction(BinaryValueHandle* func_handle,
                            BinaryValueHandle* this_handle,
                            BinaryValueHandle* argv_handle,
                            uint64_t callback_id) -> uint64_t {
-  auto func_ptr = bv_factory_->FromHandle(func_handle);
-  if (!func_ptr) {
-    auto err = bv_factory_->New("Bad handle: func", type_value_exception);
-    return RunTask([err](v8::Isolate* /*isolate*/) { return err; },
-                   callback_id);
+  auto func_hc = MakeHandleConverter(func_handle, "Bad handle: func");
+  if (!func_hc) {
+    return RunTask(
+        [err = func_hc.GetErrorPtr()](v8::Isolate* /*isolate*/) { return err; },
+        callback_id);
   }
 
-  auto this_ptr = bv_factory_->FromHandle(this_handle);
-  if (!this_ptr) {
-    auto err = bv_factory_->New("Bad handle: this", type_value_exception);
-    return RunTask([err](v8::Isolate* /*isolate*/) { return err; },
-                   callback_id);
+  auto this_hc = MakeHandleConverter(this_handle, "Bad handle: this");
+  if (!this_hc) {
+    return RunTask(
+        [err = this_hc.GetErrorPtr()](v8::Isolate* /*isolate*/) { return err; },
+        callback_id);
   }
 
-  auto argv_ptr = bv_factory_->FromHandle(argv_handle);
-  if (!argv_ptr) {
-    auto err = bv_factory_->New("Bad handle: argv", type_value_exception);
-    return RunTask([err](v8::Isolate* /*isolate*/) { return err; },
-                   callback_id);
+  auto argv_hc = MakeHandleConverter(argv_handle, "Bad handle: argv");
+  if (!argv_hc) {
+    return RunTask(
+        [err = argv_hc.GetErrorPtr()](v8::Isolate* /*isolate*/) { return err; },
+        callback_id);
   }
 
   return RunTask(
-      [object_manipulator = object_manipulator_, func_ptr, this_ptr,
-       argv_ptr](v8::Isolate* isolate) {
+      [object_manipulator = object_manipulator_, func_ptr = func_hc.GetPtr(),
+       this_ptr = this_hc.GetPtr(),
+       argv_ptr = argv_hc.GetPtr()](v8::Isolate* isolate) {
         return object_manipulator->Call(isolate, func_ptr.get(), this_ptr.get(),
                                         argv_ptr.get());
       },
@@ -287,7 +309,7 @@ auto Context::CallFunction(BinaryValueHandle* func_handle,
 }
 
 auto Context::BinaryValueCount() -> size_t {
-  return bv_factory_->Count();
+  return bv_registry_->Count();
 }
 
 }  // end namespace MiniRacer

--- a/src/v8_py_frontend/js_callback_maker.cc
+++ b/src/v8_py_frontend/js_callback_maker.cc
@@ -20,14 +20,14 @@ namespace MiniRacer {
 
 JSCallbackCaller::JSCallbackCaller(
     std::shared_ptr<BinaryValueFactory> bv_factory,
-    Callback callback)
-    : bv_factory_(std::move(bv_factory)), callback_(callback) {}
+    RememberValueAndCallback callback)
+    : bv_factory_(std::move(bv_factory)), callback_(std::move(callback)) {}
 
 void JSCallbackCaller::DoCallback(v8::Local<v8::Context> context,
                                   uint64_t callback_id,
                                   v8::Local<v8::Array> args) {
   const BinaryValue::Ptr args_ptr = bv_factory_->New(context, args);
-  callback_(callback_id, args_ptr->GetHandle());
+  callback_(callback_id, args_ptr);
 }
 
 std::shared_ptr<IdMaker<JSCallbackCaller>> JSCallbackMaker::callback_callers_;
@@ -44,11 +44,11 @@ auto JSCallbackMaker::GetCallbackCallers()
 JSCallbackMaker::JSCallbackMaker(
     std::shared_ptr<ContextHolder> context_holder,
     const std::shared_ptr<BinaryValueFactory>& bv_factory,
-    Callback callback)
+    RememberValueAndCallback callback)
     : context_holder_(std::move(context_holder)),
       bv_factory_(bv_factory),
       callback_caller_holder_(
-          std::make_shared<JSCallbackCaller>(bv_factory, callback),
+          std::make_shared<JSCallbackCaller>(bv_factory, std::move(callback)),
           GetCallbackCallers()) {}
 
 auto JSCallbackMaker::MakeJSCallback(v8::Isolate* isolate,

--- a/src/v8_py_frontend/js_callback_maker.h
+++ b/src/v8_py_frontend/js_callback_maker.h
@@ -24,7 +24,7 @@ namespace MiniRacer {
 class JSCallbackCaller {
  public:
   JSCallbackCaller(std::shared_ptr<BinaryValueFactory> bv_factory,
-                   Callback callback);
+                   RememberValueAndCallback callback);
 
   void DoCallback(v8::Local<v8::Context> context,
                   uint64_t callback_id,
@@ -32,7 +32,7 @@ class JSCallbackCaller {
 
  private:
   std::shared_ptr<BinaryValueFactory> bv_factory_;
-  Callback callback_;
+  RememberValueAndCallback callback_;
 };
 
 /** Creates a JS callback wrapped around the given C callback function pointer.
@@ -41,7 +41,7 @@ class JSCallbackMaker {
  public:
   JSCallbackMaker(std::shared_ptr<ContextHolder> context_holder,
                   const std::shared_ptr<BinaryValueFactory>& bv_factory,
-                  Callback callback);
+                  RememberValueAndCallback callback);
 
   auto MakeJSCallback(v8::Isolate* isolate,
                       uint64_t callback_id) -> BinaryValue::Ptr;


### PR DESCRIPTION
Before `BinaryValueFactory` had two missions: creating `BinaryValue`s with a special deleter in them, and remembering the `BinaryValue`s when exchanging them back to Python.

There was one case we didn't want the latter (canceled tasks) requiring special logic there to forget unwanted values. Also, combining these jobs was sort of confusing because you'd get a `shared_ptr<BinaryValue>` back from `BinaryValueFactory::New` which *wouldn't actually delete the object upon its own* (because the factory was saving its own `shared_ptr` reference as a side effect of value creation).

Now we explicitly "Remember" `BinaryValue`s when returning them to Python (as `BinaryValueHandle`s), using a new class, the `BinaryValueRegistry`.