### PR TITLE
Fix freeze on shutdown with eternal microtasks

### DIFF
--- a/hatch_build.py
+++ b/hatch_build.py
@@ -9,7 +9,7 @@ from packaging.tags import Tag
 # During env initialization the PYTHONPATH doesn't include our helpers, so
 # give it some help:
 syspath.append(dirname(__file__))
-from helpers.v8_build import build_v8, clean_v8, get_platform_tag  # noqa: E402
+from helpers.v8_build import build_v8, clean_v8, get_platform_tag
 
 
 class V8BuildHook(BuildHookInterface[BuilderConfig]):

--- a/helpers/babel.py
+++ b/helpers/babel.py
@@ -1,4 +1,4 @@
-""" Transform the input stream using babel.transform """
+"""Transform the input stream using babel.transform"""
 
 import os
 import sys
@@ -20,18 +20,18 @@ def babel_transform(es_string):
     ctx = py_mini_racer.MiniRacer()
 
     # Parse babel
-    ctx.eval("""var self = this; %s """ % babel_source)
+    ctx.eval(f"var self = this; {babel_source}" "")
 
     # Transform stuff :)
-    val = "babel.transform(`%s`)['code']" % es_string
+    val = f"babel.transform(`{es_string}`)['code']"
     return ctx.eval(val)
 
 
 if __name__ == "__main__":
     if len(sys.argv) != 1:
         name = sys.argv[0]
-        sys.stderr.write("Usage: cat es6file.js | %s\n" % name)
-        sys.stderr.write("Example: echo [1,2,3].map(n => n + 1); | %s\n" % name)
+        sys.stderr.write(f"Usage: cat es6file.js | {name}\n")
+        sys.stderr.write(f"Example: echo [1,2,3].map(n => n + 1); | {name}\n")
         sys.exit(-1)
 
     es6_data = sys.stdin.read()

--- a/src/py_mini_racer/_types.py
+++ b/src/py_mini_racer/_types.py
@@ -1,4 +1,5 @@
 """Declarations for Python renderings of basic JavaScript types."""
+
 from __future__ import annotations
 
 from datetime import datetime

--- a/src/py_mini_racer/_value_handle.py
+++ b/src/py_mini_racer/_value_handle.py
@@ -90,16 +90,16 @@ class MiniRacerTypes:
 
     invalid = 0
     null = 1
-    bool = 2  # noqa: A003
+    bool = 2
     integer = 3
     double = 4
     str_utf8 = 5
     array = 6
     # deprecated:
-    hash = 7  # noqa: A003
+    hash = 7
     date = 8
     symbol = 9
-    object = 10  # noqa: A003
+    object = 10
     undefined = 11
 
     function = 100

--- a/src/v8_py_frontend/context.h
+++ b/src/v8_py_frontend/context.h
@@ -63,9 +63,7 @@ class Context {
 
  private:
   template <typename Runnable>
-  auto RunTask(Runnable runnable,
-
-               uint64_t callback_id) -> uint64_t;
+  auto RunTask(Runnable runnable, uint64_t callback_id) -> uint64_t;
 
   auto MakeHandleConverter(BinaryValueHandle* handle,
                            const char* err_msg) -> ValueHandleConverter;

--- a/src/v8_py_frontend/context_holder.cc
+++ b/src/v8_py_frontend/context_holder.cc
@@ -21,7 +21,7 @@ ContextHolder::ContextHolder(std::shared_ptr<IsolateManager> isolate_manager)
       })) {}
 
 ContextHolder::~ContextHolder() {
-  isolate_manager_->RunAndAwait(
+  isolate_manager_->Run(
       [context = std::move(context_)](v8::Isolate*) { context->Reset(); });
 }
 

--- a/src/v8_py_frontend/isolate_memory_monitor.cc
+++ b/src/v8_py_frontend/isolate_memory_monitor.cc
@@ -36,12 +36,11 @@ auto IsolateMemoryMonitor::IsHardMemoryLimitReached() const -> bool {
 
 void IsolateMemoryMonitor::ApplyLowMemoryNotification() {
   isolate_manager_->RunAndAwait(
-      [](v8::Isolate* isolate) { isolate->LowMemoryNotification(); },
-      /*interrupt=*/true);
+      [](v8::Isolate* isolate) { isolate->LowMemoryNotification(); });
 }
 
 IsolateMemoryMonitor::~IsolateMemoryMonitor() {
-  isolate_manager_->RunAndAwait([state = state_](v8::Isolate* isolate) {
+  isolate_manager_->Run([state = state_](v8::Isolate* isolate) {
     isolate->RemoveGCEpilogueCallback(&IsolateMemoryMonitor::StaticGCCallback,
                                       state.get());
   });

--- a/tests/test_babel.py
+++ b/tests/test_babel.py
@@ -1,4 +1,4 @@
-""" Test loading and executing babel.js """
+"""Test loading and executing babel.js"""
 
 from os.path import dirname
 from os.path import join as pathjoin
@@ -12,16 +12,13 @@ def test_babel(gc_check):
     path = pathjoin(dirname(__file__), "fixtures/babel.js")
     with open(path, encoding="utf-8") as f:
         babel_source = f.read()
-    source = (
-        """
+    source = f"""
       var self = this;
-      %s
-      babel.eval = function(code) {
+      {babel_source}
+      babel.eval = function(code) {{
         return eval(babel.transform(code)["code"]);
-      }
+      }}
     """
-        % babel_source
-    )
     mr.eval(source)
     assert mr.eval("babel.eval(((x) => x * x)(8))") == 64
 

--- a/tests/test_call.py
+++ b/tests/test_call.py
@@ -1,4 +1,4 @@
-""" Basic JS call functions """
+"""Basic JS call functions"""
 
 from datetime import datetime, timezone
 from json import JSONEncoder

--- a/tests/test_eval.py
+++ b/tests/test_eval.py
@@ -1,4 +1,4 @@
-""" Test .eval() method """
+"""Test .eval() method"""
 
 from asyncio import run as asyncio_run
 from time import sleep, time

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -1,4 +1,4 @@
-""" Tests JSFunctions """
+"""Tests JSFunctions"""
 
 import pytest
 from py_mini_racer import (

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -50,3 +50,14 @@ def test_del():
         sleep(0.1)
 
     assert context_count() == count_before
+
+
+def test_interrupts_background_task_on_shutdown():
+    with MiniRacer() as mr:
+        # Schedule a never-ending background task:
+        mr.eval("setTimeout(() => { while (1); }, 1);")
+        # Make sure the task starts:
+        sleep(0.1)
+        # Now at the end of the with statement, we explicitly close the instance, which
+        # should terminate the background task (as oppposed to hanging indefinitely
+        # here).

--- a/tests/test_py_js_function.py
+++ b/tests/test_py_js_function.py
@@ -1,4 +1,4 @@
-""" Test Python functions exposed as JS."""
+"""Test Python functions exposed as JS."""
 
 from asyncio import gather
 from asyncio import run as asyncio_run

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -1,4 +1,4 @@
-""" Basic JS types tests """
+"""Basic JS types tests"""
 
 from datetime import datetime, timezone
 from json import dumps
@@ -231,7 +231,7 @@ def test_shared_array_buffer(gc_check):
     ret = mr.eval(js_source)
     assert len(ret) == 1024
     assert ret[0:1].tobytes() == b"\x42"
-    ret[1:2] = b"\xFF"
+    ret[1:2] = b"\xff"
     assert mr.eval("v[1]") == 0xFF
 
     del ret


### PR DESCRIPTION
`test_interrupts_background_task_on_shutdown` contains an example infinite-loop microtask which would (without this change) prevent MiniRacer from ever exiting.

This also adds an explicit `close` and context manager around `MiniRacer` on the Python side, which would have been nice to have already, and is useful here to write the unit test.