### PR TITLE
Fix isolate leak on teardown

### DIFF
--- a/src/v8_py_frontend/cancelable_task_runner.cc
+++ b/src/v8_py_frontend/cancelable_task_runner.cc
@@ -1,64 +1,52 @@
 #include "cancelable_task_runner.h"
 
 #include <cstdint>
+#include <future>
 #include <memory>
-#include <mutex>
 #include <utility>
+#include <vector>
 #include "id_maker.h"
 #include "isolate_manager.h"
 
 namespace MiniRacer {
 
-CancelableTaskState::CancelableTaskState() : state_(State::kNotStarted) {}
-
-void CancelableTaskState::Cancel(IsolateManager* isolate_manager) {
-  const std::lock_guard<std::mutex> lock(mutex_);
-
-  if (state_ == State::kCanceled || state_ == State::kCompleted) {
-    return;
-  }
-
-  if (state_ == State::kRunning) {
-    isolate_manager->TerminateOngoingTask();
-  }
-
-  state_ = State::kCanceled;
+void CancelableTaskBase::SetFuture(std::future<void> fut) {
+  future_promise_.set_value(std::move(fut));
 }
 
-auto CancelableTaskState::SetRunningIfNotCanceled() -> bool {
-  const std::lock_guard<std::mutex> lock(mutex_);
-  if (state_ == State::kCanceled) {
-    return false;
-  }
-
-  state_ = State::kRunning;
-  return true;
+void CancelableTaskBase::Await() {
+  future_promise_.get_future().get();
 }
 
-auto CancelableTaskState::SetCompleteIfNotCanceled() -> bool {
-  const std::lock_guard<std::mutex> lock(mutex_);
-  if (state_ == State::kCanceled) {
-    return false;
+CancelableTaskManager::CancelableTaskManager(IsolateManager* isolate_manager)
+    : isolate_manager_(isolate_manager),
+      task_id_maker_(std::make_shared<IdMaker<CancelableTaskBase>>()) {}
+
+CancelableTaskManager::~CancelableTaskManager() {
+  // Normally, completed or canceled tasks will clean themselves out of the
+  // IdMaker. However, some tasks may still be pending upon teardown. Let's
+  // explicitly cancel and await any stragglers:
+  const std::vector<std::shared_ptr<CancelableTaskBase>> pending_tasks =
+      task_id_maker_->GetObjects();
+
+  for (const auto& task : pending_tasks) {
+    task->Cancel(isolate_manager_);
   }
 
-  state_ = State::kCompleted;
-  return true;
+  for (const auto& task : pending_tasks) {
+    task->Await();
+  }
 }
 
-CancelableTaskRunner::CancelableTaskRunner(
-    std::shared_ptr<IsolateManager> isolate_manager)
-    : isolate_manager_(std::move(isolate_manager)),
-      task_id_maker_(std::make_shared<IdMaker<CancelableTaskState>>()) {}
-
-void CancelableTaskRunner::Cancel(uint64_t task_id) {
-  const std::shared_ptr<CancelableTaskState> task_state =
+void CancelableTaskManager::Cancel(uint64_t task_id) {
+  const std::shared_ptr<CancelableTaskBase> task =
       task_id_maker_->GetObject(task_id);
-  if (!task_state) {
+  if (!task) {
     // No such task found. This will commonly happen if a task is canceled
     // after it has already completed.
     return;
   }
-  task_state->Cancel(isolate_manager_.get());
+  task->Cancel(isolate_manager_);
 }
 
 }  // end namespace MiniRacer

--- a/src/v8_py_frontend/cancelable_task_runner.h
+++ b/src/v8_py_frontend/cancelable_task_runner.h
@@ -2,6 +2,7 @@
 #define INCLUDE_MINI_RACER_CANCELABLE_TASK_RUNNER_H
 
 #include <cstdint>
+#include <future>
 #include <memory>
 #include <mutex>
 #include <utility>
@@ -11,32 +12,39 @@
 
 namespace MiniRacer {
 
-/** Keeps track of status of a cancelable task. */
-class CancelableTaskState {
+class CancelableTaskBase {
  public:
-  explicit CancelableTaskState();
+  CancelableTaskBase() = default;
+  virtual ~CancelableTaskBase() = default;
 
-  void Cancel(IsolateManager* isolate_manager);
+  CancelableTaskBase(const CancelableTaskBase&) = delete;
+  auto operator=(const CancelableTaskBase&) -> CancelableTaskBase& = delete;
+  CancelableTaskBase(CancelableTaskBase&&) = delete;
+  auto operator=(CancelableTaskBase&& other) -> CancelableTaskBase& = delete;
 
-  auto SetRunningIfNotCanceled() -> bool;
+  virtual void Cancel(IsolateManager* isolate_manager) = 0;
 
-  auto SetCompleteIfNotCanceled() -> bool;
+  void SetFuture(std::future<void> fut);
+  void Await();
 
  private:
-  enum State : std::uint8_t {
-    kNotStarted = 0,
-    kRunning = 1,
-    kCompleted = 2,
-    kCanceled = 3
-  } state_;
-  std::mutex mutex_;
+  // A promise which yields a future which blocks until the underlying task
+  // is complete.
+  std::promise<std::future<void>> future_promise_;
 };
 
 /** Grafts a concept of cancelable tasks on top of an IsolateManager. */
-class CancelableTaskRunner {
+class CancelableTaskManager {
  public:
-  explicit CancelableTaskRunner(
-      std::shared_ptr<IsolateManager> isolate_manager);
+  explicit CancelableTaskManager(IsolateManager* isolate_manager);
+  ~CancelableTaskManager();
+
+  CancelableTaskManager(const CancelableTaskManager&) = delete;
+  auto operator=(const CancelableTaskManager&) -> CancelableTaskManager& =
+                                                      delete;
+  CancelableTaskManager(CancelableTaskManager&&) = delete;
+  auto operator=(CancelableTaskManager&& other) -> CancelableTaskManager& =
+                                                       delete;
 
   /**
    * Schedule the given runnable.
@@ -48,7 +56,7 @@ class CancelableTaskRunner {
    * those two functions will be called.)
    *
    * We split up these into separate functors to discourage side-channel passing
-   * of result data; the caller should follow the CancelableTaskRunner's view
+   * of result data; the caller should follow the CancelableTaskManager's view
    * regarding whether the task was completed or canceled.
    */
   template <typename Runnable, typename OnCompleted, typename OnCanceled>
@@ -59,62 +67,98 @@ class CancelableTaskRunner {
   void Cancel(uint64_t task_id);
 
  private:
-  std::shared_ptr<IsolateManager> isolate_manager_;
-  std::shared_ptr<IdMaker<CancelableTaskState>> task_id_maker_;
+  IsolateManager* isolate_manager_;
+  std::shared_ptr<IdMaker<CancelableTaskBase>> task_id_maker_;
 };
 
 template <typename Runnable, typename OnCompleted, typename OnCanceled>
-class CancelableTask {
+class CancelableTask : public CancelableTaskBase {
  public:
-  CancelableTask(Runnable runnable,
-                 OnCompleted on_completed,
-                 OnCanceled on_canceled,
-                 std::shared_ptr<IdMaker<CancelableTaskState>> task_id_maker);
+  explicit CancelableTask(Runnable runnable,
+                          OnCompleted on_completed,
+                          OnCanceled on_canceled);
 
   void Run(v8::Isolate* isolate);
-
-  auto TaskId() -> uint64_t;
+  void Cancel(IsolateManager* isolate_manager) override;
 
  private:
   Runnable runnable_;
   OnCompleted on_completed_;
   OnCanceled on_canceled_;
-  std::shared_ptr<CancelableTaskState> task_state_;
-  IdHolder<CancelableTaskState> task_id_holder_;
+
+  std::mutex mutex_;
+  enum State : std::uint8_t {
+    kNotStarted = 0,
+    kRunning = 1,
+    kCompleted = 2,
+    kCanceled = 3
+  } state_;
 };
+
+template <typename Runnable, typename OnCompleted, typename OnCanceled>
+inline auto CancelableTaskManager::Schedule(Runnable runnable,
+                                            OnCompleted on_completed,
+                                            OnCanceled on_canceled)
+    -> uint64_t {
+  auto task =
+      std::make_shared<CancelableTask<Runnable, OnCompleted, OnCanceled>>(
+          std::move(runnable), std::move(on_completed), std::move(on_canceled));
+
+  IdHolder<CancelableTaskBase> task_id_holder(task, task_id_maker_);
+
+  const uint64_t task_id = task_id_holder.GetId();
+
+  std::future<void> fut = isolate_manager_->Run(
+      [holder = std::move(task_id_holder), task](v8::Isolate* isolate) mutable {
+        task->Run(isolate);
+      });
+
+  task->SetFuture(std::move(fut));
+
+  return task_id;
+}
 
 template <typename Runnable, typename OnCompleted, typename OnCanceled>
 inline CancelableTask<Runnable, OnCompleted, OnCanceled>::CancelableTask(
     Runnable runnable,
     OnCompleted on_completed,
-    OnCanceled on_canceled,
-    std::shared_ptr<IdMaker<CancelableTaskState>> task_id_maker)
+    OnCanceled on_canceled)
     : runnable_(std::move(runnable)),
       on_completed_(std::move(on_completed)),
       on_canceled_(std::move(on_canceled)),
-      task_state_(std::make_shared<CancelableTaskState>()),
-      task_id_holder_(task_state_, std::move(task_id_maker)) {}
-
-template <typename Runnable, typename OnCompleted, typename OnCanceled>
-inline auto CancelableTask<Runnable, OnCompleted, OnCanceled>::TaskId()
-    -> uint64_t {
-  return task_id_holder_.GetId();
-}
+      state_(State::kNotStarted) {}
 
 template <typename Runnable, typename OnCompleted, typename OnCanceled>
 inline void CancelableTask<Runnable, OnCompleted, OnCanceled>::Run(
     v8::Isolate* isolate) {
-  if (!task_state_->SetRunningIfNotCanceled()) {
-    // Canceled before we started the task.
-    on_canceled_({});
+  bool was_canceled_before_run = false;
+  {
+    const std::lock_guard<std::mutex> lock(mutex_);
+    if (state_ == State::kCanceled) {
+      was_canceled_before_run = true;
+    } else {
+      state_ = State::kRunning;
+    }
+  }
 
+  if (was_canceled_before_run) {
+    on_canceled_({});
     return;
   }
 
   auto result = runnable_(isolate);
 
-  if (!task_state_->SetCompleteIfNotCanceled()) {
-    // Canceled while running.
+  bool was_canceled_during_run = false;
+  {
+    const std::lock_guard<std::mutex> lock(mutex_);
+    if (state_ == State::kCanceled) {
+      was_canceled_during_run = true;
+    } else {
+      state_ = State::kCompleted;
+    }
+  }
+
+  if (was_canceled_during_run) {
     // Note that we might actually complete our call to runnable_() and still
     // report the task as canceled, if a cancel request comes in right at the
     // end. Or we might have been halfway through running some JavaScript code
@@ -134,26 +178,19 @@ inline void CancelableTask<Runnable, OnCompleted, OnCanceled>::Run(
 }
 
 template <typename Runnable, typename OnCompleted, typename OnCanceled>
-inline auto CancelableTaskRunner::Schedule(Runnable runnable,
-                                           OnCompleted on_completed,
-                                           OnCanceled on_canceled) -> uint64_t {
-  auto task =
-      std::make_unique<CancelableTask<Runnable, OnCompleted, OnCanceled>>(
-          std::move(runnable), std::move(on_completed), std::move(on_canceled),
-          task_id_maker_);
+inline void CancelableTask<Runnable, OnCompleted, OnCanceled>::Cancel(
+    IsolateManager* isolate_manager) {
+  const std::lock_guard<std::mutex> lock(mutex_);
 
-  uint64_t task_id = task->TaskId();
+  if (state_ == State::kCanceled || state_ == State::kCompleted) {
+    return;
+  }
 
-  // clang-tidy-18 gives a strange warning about a memory leak here, which would
-  // seem to me to be impossible since we're only using a unique_ptr. (And
-  // testing demonstrates we don't leak here.)
-  // NOLINTBEGIN(clang-analyzer-cplusplus.NewDeleteLeaks)
-  isolate_manager_->Run([task = std::move(task)](v8::Isolate* isolate) mutable {
-    task->Run(isolate);
-  });
-  // NOLINTEND(clang-analyzer-cplusplus.NewDeleteLeaks)
+  if (state_ == State::kRunning) {
+    isolate_manager->TerminateOngoingTask();
+  }
 
-  return task_id;
+  state_ = State::kCanceled;
 }
 
 }  // end namespace MiniRacer

--- a/src/v8_py_frontend/code_evaluator.cc
+++ b/src/v8_py_frontend/code_evaluator.cc
@@ -9,21 +9,18 @@
 #include <v8-primitive.h>
 #include <v8-script.h>
 #include <v8-value.h>
-#include <memory>
-#include <utility>
 #include "binary_value.h"
 #include "context_holder.h"
 #include "isolate_memory_monitor.h"
 
 namespace MiniRacer {
 
-CodeEvaluator::CodeEvaluator(
-    std::shared_ptr<ContextHolder> context,
-    std::shared_ptr<BinaryValueFactory> bv_factory,
-    std::shared_ptr<IsolateMemoryMonitor> memory_monitor)
-    : context_(std::move(context)),
-      bv_factory_(std::move(bv_factory)),
-      memory_monitor_(std::move(memory_monitor)) {}
+CodeEvaluator::CodeEvaluator(ContextHolder* context,
+                             BinaryValueFactory* bv_factory,
+                             IsolateMemoryMonitor* memory_monitor)
+    : context_(context),
+      bv_factory_(bv_factory),
+      memory_monitor_(memory_monitor) {}
 
 auto CodeEvaluator::Eval(v8::Isolate* isolate,
                          BinaryValue* code_ptr) -> BinaryValue::Ptr {

--- a/src/v8_py_frontend/code_evaluator.h
+++ b/src/v8_py_frontend/code_evaluator.h
@@ -5,7 +5,6 @@
 #include <v8-isolate.h>
 #include <v8-local-handle.h>
 #include <v8-persistent-handle.h>
-#include <memory>
 #include "binary_value.h"
 #include "context_holder.h"
 #include "isolate_memory_monitor.h"
@@ -15,16 +14,16 @@ namespace MiniRacer {
 /** Parse and run arbitrary scripts within an isolate. */
 class CodeEvaluator {
  public:
-  CodeEvaluator(std::shared_ptr<ContextHolder> context,
-                std::shared_ptr<BinaryValueFactory> bv_factory,
-                std::shared_ptr<IsolateMemoryMonitor> memory_monitor);
+  CodeEvaluator(ContextHolder* context,
+                BinaryValueFactory* bv_factory,
+                IsolateMemoryMonitor* memory_monitor);
 
   auto Eval(v8::Isolate* isolate, BinaryValue* code_ptr) -> BinaryValue::Ptr;
 
  private:
-  std::shared_ptr<ContextHolder> context_;
-  std::shared_ptr<BinaryValueFactory> bv_factory_;
-  std::shared_ptr<IsolateMemoryMonitor> memory_monitor_;
+  ContextHolder* context_;
+  BinaryValueFactory* bv_factory_;
+  IsolateMemoryMonitor* memory_monitor_;
 };
 
 }  // end namespace MiniRacer

--- a/src/v8_py_frontend/context_holder.cc
+++ b/src/v8_py_frontend/context_holder.cc
@@ -10,19 +10,22 @@
 
 namespace MiniRacer {
 
-ContextHolder::ContextHolder(std::shared_ptr<IsolateManager> isolate_manager)
-    : isolate_manager_(std::move(isolate_manager)),
-      context_(isolate_manager_->RunAndAwait([](v8::Isolate* isolate) {
-        const v8::Isolate::Scope isolate_scope(isolate);
-        const v8::HandleScope handle_scope(isolate);
+ContextHolder::ContextHolder(IsolateManager* isolate_manager)
+    : isolate_manager_(isolate_manager),
+      context_(isolate_manager_
+                   ->Run([](v8::Isolate* isolate) {
+                     const v8::Isolate::Scope isolate_scope(isolate);
+                     const v8::HandleScope handle_scope(isolate);
 
-        return std::make_unique<v8::Persistent<v8::Context>>(
-            isolate, v8::Context::New(isolate));
-      })) {}
+                     return std::make_unique<v8::Persistent<v8::Context>>(
+                         isolate, v8::Context::New(isolate));
+                   })
+                   .get()) {}
 
 ContextHolder::~ContextHolder() {
-  isolate_manager_->Run(
-      [context = std::move(context_)](v8::Isolate*) { context->Reset(); });
+  isolate_manager_
+      ->Run([context = std::move(context_)](v8::Isolate*) { context->Reset(); })
+      .get();
 }
 
 }  // end namespace MiniRacer

--- a/src/v8_py_frontend/context_holder.h
+++ b/src/v8_py_frontend/context_holder.h
@@ -11,7 +11,7 @@ namespace MiniRacer {
 /** Create and manage a v8::Context */
 class ContextHolder {
  public:
-  explicit ContextHolder(std::shared_ptr<IsolateManager> isolate_manager);
+  explicit ContextHolder(IsolateManager* isolate_manager);
   ~ContextHolder();
 
   ContextHolder(const ContextHolder&) = delete;
@@ -22,7 +22,7 @@ class ContextHolder {
   auto Get() -> v8::Persistent<v8::Context>*;
 
  private:
-  std::shared_ptr<IsolateManager> isolate_manager_;
+  IsolateManager* isolate_manager_;
   std::unique_ptr<v8::Persistent<v8::Context>> context_;
 };
 

--- a/src/v8_py_frontend/heap_reporter.cc
+++ b/src/v8_py_frontend/heap_reporter.cc
@@ -5,16 +5,14 @@
 #include <v8-primitive.h>
 #include <v8-profiler.h>
 #include <v8-statistics.h>
-#include <memory>
 #include <sstream>
 #include <string>
-#include <utility>
 #include "binary_value.h"
 
 namespace MiniRacer {
 
-HeapReporter::HeapReporter(std::shared_ptr<BinaryValueFactory> bv_factory)
-    : bv_factory_(std::move(bv_factory)) {}
+HeapReporter::HeapReporter(BinaryValueFactory* bv_factory)
+    : bv_factory_(bv_factory) {}
 
 auto HeapReporter::HeapStats(v8::Isolate* isolate) -> BinaryValue::Ptr {
   const v8::Isolate::Scope isolatescope(isolate);

--- a/src/v8_py_frontend/heap_reporter.h
+++ b/src/v8_py_frontend/heap_reporter.h
@@ -2,7 +2,6 @@
 #define INCLUDE_MINI_RACER_HEAP_REPORTER_H
 
 #include <v8-isolate.h>
-#include <memory>
 #include "binary_value.h"
 
 namespace MiniRacer {
@@ -10,13 +9,13 @@ namespace MiniRacer {
 /** Report fun facts about an isolate heap */
 class HeapReporter {
  public:
-  explicit HeapReporter(std::shared_ptr<BinaryValueFactory> bv_factory);
+  explicit HeapReporter(BinaryValueFactory* bv_factory);
 
   auto HeapSnapshot(v8::Isolate* isolate) -> BinaryValue::Ptr;
   auto HeapStats(v8::Isolate* isolate) -> BinaryValue::Ptr;
 
  private:
-  std::shared_ptr<BinaryValueFactory> bv_factory_;
+  BinaryValueFactory* bv_factory_;
 };
 
 }  // end namespace MiniRacer

--- a/src/v8_py_frontend/isolate_manager.cc
+++ b/src/v8_py_frontend/isolate_manager.cc
@@ -3,92 +3,63 @@
 #include <v8-isolate.h>
 #include <v8-local-handle.h>
 #include <v8-locker.h>
-#include <v8-microtask-queue.h>
 #include <v8-platform.h>
-#include <future>
-#include <memory>
 #include <thread>
+#include <tuple>
 #include "isolate_holder.h"
 
 namespace MiniRacer {
 
 IsolateManager::IsolateManager(v8::Platform* platform)
     : platform_(platform),
-      message_pump_(std::make_shared<IsolateMessagePump>(platform)),
-      isolate_(IsolateMessagePump::Start(message_pump_)) {}
+      state_(State::kRun),
+      thread_([this]() { PumpMessages(); }) {}
 
 IsolateManager::~IsolateManager() {
-  Run([message_pump = message_pump_](v8::Isolate*) {
-    message_pump->ShutDown();
-  });
+  ChangeState(State::kStop);
+  thread_.join();
 }
 
 void IsolateManager::TerminateOngoingTask() {
-  isolate_->TerminateExecution();
+  isolate_holder_.Get()->TerminateExecution();
 }
 
-IsolateMessagePump::IsolateMessagePump(v8::Platform* platform)
-    : platform_(platform),
-      shutdown_flag_(false),
-      isolate_future_(isolate_promise_.get_future()) {}
-
-auto IsolateMessagePump::Start(
-    const std::shared_ptr<IsolateMessagePump>& message_pump) -> v8::Isolate* {
-  // We intentionally copy the shared_ptr here so we hold onto a reference to
-  // the IsolateMessagePump object for the life of the pump thread:
-  auto thread = std::thread([pump = message_pump]() { pump->PumpMessages(); });
-
-  // Because the IsolateManager is managed by a std::shared_ptr, it is
-  // destructed in less-than-predictable places which include callees of
-  // this thread's message pump. Because ~IsolateManager may thus be
-  // called by this thread, it's impossible to thread.join() it (a thread
-  // can't join itself!). So instead we simply detach the thread, and
-  // trust that it will clean itself up:
-  thread.detach();
-
-  // Blocks until the thread produces its isolate:
-  return message_pump->isolate_future_.get();
+void IsolateManager::StopJavaScript() {
+  ChangeState(State::kNoJavaScript);
+  TerminateOngoingTask();
 }
 
-void IsolateMessagePump::ShutDown() {
-  shutdown_flag_ = true;
-}
-
-void IsolateMessagePump::PumpMessages() {
-  IsolateHolder isolate_holder;
-
+void IsolateManager::PumpMessages() {
   // By design, only this, the message pump thread, is ever allowed to touch
   // the isolate, so go ahead and lock it:
-  const v8::Locker lock(isolate_holder.Get());
-  const v8::Isolate::Scope scope(isolate_holder.Get());
+  v8::Isolate* isolate = isolate_holder_.Get();
+  const v8::Locker lock(isolate);
+  const v8::Isolate::Scope scope(isolate);
 
-  // However, some APIs, like posting and terminating tasks, don't require the
-  // lock. For such APIs, expose the isolate pointer:
-  isolate_promise_.set_value(isolate_holder.Get());
-
-  const v8::SealHandleScope shs(isolate_holder.Get());
-  while (!shutdown_flag_) {
+  const v8::SealHandleScope shs(isolate);
+  while (state_ == State::kRun) {
     v8::platform::PumpMessageLoop(
-        platform_, isolate_holder.Get(),
-        v8::platform::MessageLoopBehavior::kWaitForWork);
+        platform_, isolate, v8::platform::MessageLoopBehavior::kWaitForWork);
 
-    if (!shutdown_flag_) {
-      v8::MicrotasksScope::PerformCheckpoint(isolate_holder.Get());
+    if (state_ == State::kRun) {
+      isolate->PerformMicrotaskCheckpoint();
     }
   }
 
-  // Drain the message queue. This is important because we may have memory
-  // cleanup tasks on it:
-  while (v8::platform::PumpMessageLoop(
-      platform_, isolate_holder.Get(),
-      v8::platform::MessageLoopBehavior::kDoNotWait)) {
+  const v8::Isolate::DisallowJavascriptExecutionScope disallow_js(
+      isolate, v8::Isolate::DisallowJavascriptExecutionScope::OnFailure::
+                   THROW_ON_FAILURE);
+  while (state_ == State::kNoJavaScript) {
+    v8::platform::PumpMessageLoop(
+        platform_, isolate, v8::platform::MessageLoopBehavior::kWaitForWork);
   }
 }
 
-void IsolateManager::RunInterrupt(v8::Isolate* /*isolate*/, void* data) {
-  std::unique_ptr<v8::Task> task(static_cast<v8::Task*>(data));
-
-  task->Run();
+void IsolateManager::ChangeState(State state) {
+  state_ = state;
+  // Run a no-op task to kick the message loop into noticing we've switched
+  // states:
+  std::ignore = Run([](v8::Isolate*) {});
 }
 
 }  // end namespace MiniRacer

--- a/src/v8_py_frontend/isolate_memory_monitor.h
+++ b/src/v8_py_frontend/isolate_memory_monitor.h
@@ -13,8 +13,7 @@ class IsolateMemoryMonitorState;
 
 class IsolateMemoryMonitor {
  public:
-  explicit IsolateMemoryMonitor(
-      const std::shared_ptr<IsolateManager>& isolate_manager);
+  explicit IsolateMemoryMonitor(IsolateManager* isolate_manager);
   ~IsolateMemoryMonitor();
 
   IsolateMemoryMonitor(const IsolateMemoryMonitor&) = delete;
@@ -36,14 +35,13 @@ class IsolateMemoryMonitor {
                                v8::GCCallbackFlags flags,
                                void* data);
 
-  std::shared_ptr<IsolateManager> isolate_manager_;
+  IsolateManager* isolate_manager_;
   std::shared_ptr<IsolateMemoryMonitorState> state_;
 };
 
 class IsolateMemoryMonitorState {
  public:
-  explicit IsolateMemoryMonitorState(
-      std::shared_ptr<IsolateManager> isolate_manager);
+  explicit IsolateMemoryMonitorState();
 
   [[nodiscard]] auto IsSoftMemoryLimitReached() const -> bool;
   [[nodiscard]] auto IsHardMemoryLimitReached() const -> bool;
@@ -53,7 +51,6 @@ class IsolateMemoryMonitorState {
   void GCCallback(v8::Isolate* isolate);
 
  private:
-  std::shared_ptr<IsolateManager> isolate_manager_;
   size_t soft_memory_limit_;
   bool soft_memory_limit_reached_;
   size_t hard_memory_limit_;

--- a/src/v8_py_frontend/isolate_object_collector.cc
+++ b/src/v8_py_frontend/isolate_object_collector.cc
@@ -1,18 +1,47 @@
 #include "isolate_object_collector.h"
+#include <v8-isolate.h>
+#include <functional>
 #include <mutex>
+#include <tuple>
+#include <utility>
+#include <vector>
 #include "isolate_manager.h"
 
 namespace MiniRacer {
 
 IsolateObjectCollector::IsolateObjectCollector(IsolateManager* isolate_manager)
-    : isolate_manager_(isolate_manager) {}
+    : isolate_manager_(isolate_manager), is_collecting_(false) {}
 
-void IsolateObjectCollector::Dispose() {
-  const std::lock_guard<std::mutex> lock(mutex_);
-  for (auto& func : garbage_) {
-    func();
+IsolateObjectCollector::~IsolateObjectCollector() {
+  std::unique_lock<std::mutex> lock(mutex_);
+  collection_done_cv_.wait(lock, [this] { return !is_collecting_; });
+}
+
+void IsolateObjectCollector::StartCollectingLocked() {
+  is_collecting_ = true;
+
+  std::ignore = isolate_manager_->Run([this](v8::Isolate*) { DoCollection(); });
+}
+
+void IsolateObjectCollector::DoCollection() {
+  std::vector<std::function<void()>> batch;
+  {
+    const std::lock_guard<std::mutex> lock(mutex_);
+    batch = std::exchange(garbage_, {});
   }
-  garbage_.clear();
+
+  for (const auto& collector : batch) {
+    collector();
+  }
+
+  const std::lock_guard<std::mutex> lock(mutex_);
+  if (garbage_.empty()) {
+    is_collecting_ = false;
+    collection_done_cv_.notify_all();
+    return;
+  }
+
+  StartCollectingLocked();
 }
 
 IsolateObjectDeleter::IsolateObjectDeleter()

--- a/src/v8_py_frontend/js_callback_maker.h
+++ b/src/v8_py_frontend/js_callback_maker.h
@@ -23,7 +23,7 @@ namespace MiniRacer {
  */
 class JSCallbackCaller {
  public:
-  JSCallbackCaller(std::shared_ptr<BinaryValueFactory> bv_factory,
+  JSCallbackCaller(BinaryValueFactory* bv_factory,
                    RememberValueAndCallback callback);
 
   void DoCallback(v8::Local<v8::Context> context,
@@ -31,7 +31,7 @@ class JSCallbackCaller {
                   v8::Local<v8::Array> args);
 
  private:
-  std::shared_ptr<BinaryValueFactory> bv_factory_;
+  BinaryValueFactory* bv_factory_;
   RememberValueAndCallback callback_;
 };
 
@@ -39,8 +39,8 @@ class JSCallbackCaller {
  */
 class JSCallbackMaker {
  public:
-  JSCallbackMaker(std::shared_ptr<ContextHolder> context_holder,
-                  const std::shared_ptr<BinaryValueFactory>& bv_factory,
+  JSCallbackMaker(ContextHolder* context_holder,
+                  BinaryValueFactory* bv_factory,
                   RememberValueAndCallback callback);
 
   auto MakeJSCallback(v8::Isolate* isolate,
@@ -54,8 +54,8 @@ class JSCallbackMaker {
   static std::shared_ptr<IdMaker<JSCallbackCaller>> callback_callers_;
   static std::once_flag callback_callers_init_flag_;
 
-  std::shared_ptr<ContextHolder> context_holder_;
-  std::shared_ptr<BinaryValueFactory> bv_factory_;
+  ContextHolder* context_holder_;
+  BinaryValueFactory* bv_factory_;
   IdHolder<JSCallbackCaller> callback_caller_holder_;
 };
 

--- a/src/v8_py_frontend/object_manipulator.cc
+++ b/src/v8_py_frontend/object_manipulator.cc
@@ -9,18 +9,15 @@
 #include <v8-persistent-handle.h>
 #include <v8-primitive.h>
 #include <cstdint>
-#include <memory>
-#include <utility>
 #include <vector>
 #include "binary_value.h"
 #include "context_holder.h"
 
 namespace MiniRacer {
 
-ObjectManipulator::ObjectManipulator(
-    std::shared_ptr<ContextHolder> context,
-    std::shared_ptr<BinaryValueFactory> bv_factory)
-    : context_(std::move(context)), bv_factory_(std::move(bv_factory)) {}
+ObjectManipulator::ObjectManipulator(ContextHolder* context,
+                                     BinaryValueFactory* bv_factory)
+    : context_(context), bv_factory_(bv_factory) {}
 
 auto ObjectManipulator::GetIdentityHash(v8::Isolate* isolate,
                                         BinaryValue* obj_ptr)

--- a/src/v8_py_frontend/object_manipulator.h
+++ b/src/v8_py_frontend/object_manipulator.h
@@ -4,7 +4,6 @@
 #include <v8-isolate.h>
 #include <v8-persistent-handle.h>
 #include <cstdint>
-#include <memory>
 #include "binary_value.h"
 #include "context_holder.h"
 
@@ -18,8 +17,7 @@ namespace MiniRacer {
  * the BinaryValue pointers is done by the caller. */
 class ObjectManipulator {
  public:
-  ObjectManipulator(std::shared_ptr<ContextHolder> context,
-                    std::shared_ptr<BinaryValueFactory> bv_factory);
+  ObjectManipulator(ContextHolder* context, BinaryValueFactory* bv_factory);
 
   auto GetIdentityHash(v8::Isolate* isolate,
                        BinaryValue* obj_ptr) -> BinaryValue::Ptr;
@@ -46,8 +44,8 @@ class ObjectManipulator {
             BinaryValue* argv_ptr) -> BinaryValue::Ptr;
 
  private:
-  std::shared_ptr<ContextHolder> context_;
-  std::shared_ptr<BinaryValueFactory> bv_factory_;
+  ContextHolder* context_;
+  BinaryValueFactory* bv_factory_;
 };
 
 }  // end namespace MiniRacer

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -39,17 +39,23 @@ def test_sandbox():
 
 
 def test_del():
-    collect()
-    count_before = context_count()
+    # Collect any leftover contexts:
+    start = time()
+    while time() - start < 10 and context_count() != 0:
+        collect()
+        sleep(0.1)
+
+    assert context_count() == 0
+
     mr = MiniRacer()
     del mr
 
     start = time()
-    while time() - start < 2 and context_count() != count_before:
+    while time() - start < 10 and context_count() != 0:
         collect()
         sleep(0.1)
 
-    assert context_count() == count_before
+    assert context_count() == 0
 
 
 def test_interrupts_background_task_on_shutdown():


### PR DESCRIPTION
We were sometimes leaking isolates on shutdown because of reference cycles. In particular, the `IsolateManager` could be running a perpetual (or self-restarting) task which contains `shared_ptr` references to objects which in turn contain `shared_ptr` references to the `IsolateManager`.

This makes simplifies the lifecycle of most things in the C++ side of `PyMiniRacer`. Instead of using `shared_ptr` to manage lifecycle, we more explicitly manage lifecycles. Any classes which send tasks to the `IsolateManager` are, obviously, responsible for ensuring those tasks complete before the classes are destructed. `IsolateManager::Run` now returns a `future` to make that easier to do.

Closes https://github.com/bpcreech/PyMiniRacer/issues/62.