### PR TITLE
Switch from tags to branches for releases

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,8 +5,8 @@ on:
   pull_request: {}
   # For releases:
   push:
-    tags:
-      - v*
+    branches:
+      - 'release/*'
 
 concurrency:
   group: build-${{ github.head_ref }}
@@ -68,8 +68,8 @@ jobs:
           # releases.
           # For more info on this GitHub Actions hack, see:
           # https://stackoverflow.com/questions/65384420/how-do-i-make-a-github-action-matrix-element-conditional#answer-73822998
-          - image: ${{ !startsWith(github.ref, 'refs/tags') && 'arm64v8/debian:bullseye' }}
-          - image: ${{ !startsWith(github.ref, 'refs/tags') && 'arm64v8/alpine:3.19' }}
+          - image: ${{ !startsWith(github.ref, 'refs/heads/release/') && 'arm64v8/debian:bullseye' }}
+          - image: ${{ !startsWith(github.ref, 'refs/heads/release/') && 'arm64v8/alpine:3.19' }}
 
     steps:
     - name: Configure git
@@ -83,7 +83,7 @@ jobs:
     - name: Run sccache-cache
       uses: mozilla-actions/sccache-action@v0.0.3
       # For security reasons, only use sccache on releases:
-      if: ${{ startsWith(github.ref, 'refs/tags') }}
+      if: ${{ startsWith(github.ref, 'refs/heads/release/') }}
 
     - uses: uraimo/run-on-arch-action@v2
       name: Build wheel
@@ -323,7 +323,7 @@ jobs:
     - name: Run sccache-cache
       uses: mozilla-actions/sccache-action@v0.0.3
       # For security reasons, only use sccache on releases:
-      if: ${{ startsWith(github.ref, 'refs/tags') }}
+      if: ${{ startsWith(github.ref, 'refs/heads/release') }}
 
     - uses: actions/setup-python@v5
       with:
@@ -351,7 +351,7 @@ jobs:
 
   release:
     name: Create GitHub release
-    if: startsWith(github.ref, 'refs/tags')
+    if: startsWith(github.ref, 'refs/heads/release')
     needs:
     - linux-wheels
     - non-linux-wheels
@@ -361,14 +361,22 @@ jobs:
     steps:
     - uses: actions/download-artifact@v3
 
+    - name: Compute release version
+      run: |
+        VERSION=${GITHUB_REF_NAME#release/}
+        echo Version: $VERSION
+        echo "VERSION=$VERSION" >> $GITHUB_ENV
+
     - name: Make release
       uses: ncipollo/release-action@v1
       with:
         artifacts: "wheels/*,sdist/*"
+        commit: ${{ github.ref }}
+        tag: ${{ env.VERSION }}
 
   publish:
     name: Upload release to PyPI
-    if: startsWith(github.ref, 'refs/tags')
+    if: startsWith(github.ref, 'refs/heads/release')
     needs:
     - release
     runs-on: ubuntu-latest

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -184,28 +184,36 @@ Before you submit a pull request, check that it meets these guidelines:
 Releases for `PyMiniRacer` should be done by GitHub Actions on the official project
 repository.
 
-To release:
+### Ordinary releases
 
-1. Merge all changes into `main` on the offical repository.
+To make an ordinary release from `main`:
 
-1. Update `HISTORY.md` with a summary of changes since the last release.
+1. Merge all changes into `main` on the official repository.
 
 1. Pick the next revision number:
 
     ```sh
-    $ git fetch --tags
-    $ git tag -l
-    # observe the next available tag
+    $ git fetch
+    $ git ls-remote origin | grep refs/heads/release
+    # observe the next available release version
     ```
 
-1. Update `src/py_mini_racer/__about__.py` with the new revision number.
+1. Create a `feature/...` branch, and:
 
-1. Add and push a tag:
+    1. Update `HISTORY.md` with a summary of changes since the last release.
+
+    1. Update `src/py_mini_racer/__about__.py` with the new revision number.
+
+    1. Create and merge a pull request for this branch into `main`.
+
+1. Create a `release/...` branch:
 
     ```sh
-    NEXT_TAG=the next tag
-    $ git tag "${NEXT_TAG}"
-    $ git push origin "${NEXT_TAG}"
+    $ git checkout main
+    $ git pull
+    NEXT_RELEASE=the next tag, starting with the letter v. E.g., "v0.12.1".
+    $ git checkout -b "release/${NEXT_RELEASE}"
+    $ git push --set-upstream origin "release/${NEXT_RELEASE}"
     ```
 
 1. Observe the build process on GitHub Actions. It should build and push docs and upload
@@ -218,3 +226,38 @@ To release:
         left off due to [`sccache`](https://github.com/mozilla/sccache). The jobs should
         *eventually* complete within the time limit. You can observe their slow progress
         using the Ninja build status (e.g., `[1645/2312] CXX obj/v8_foo_bar.o`).
+
+### Hotfix releases
+
+To hotfix a prior release:
+
+1. Prepare the fix as a `feature` branch as normal, and merge it into `main`.
+
+1. Pick the next revision number. This will typically be a patch-version update on the
+    current release name.
+
+1. Create a new release branch for the hotfix:
+
+    ```sh
+    BASE_RELEASE=the release you are hotfixing, starting with the letter v. E.g., "v0.12.0".
+    NEXT_RELEASE=the next tag, starting with the letter v. E.g., "v0.12.1".
+    $ git checkout "release/${BASE_RELEASE}"
+    $ git pull
+    $ git checkout -b "release/${NEXT_RELEASE}"
+    ```
+
+1. Hotfix the commit(s) created in step #1 onto the new release branch.
+
+1. Create a version update commit:
+
+    1. Update `HISTORY.md` with a summary of changes since the last release.
+
+    1. Update `src/py_mini_racer/__about__.py` with the new revision number.
+
+1. Commit and push the new release branch to GitHub.
+
+1. Merge this branch into `main`. *All content on release branches should be included in
+    `main`.*
+
+1. Observe the build process on GitHub Actions. It should build and push docs and upload
+    wheels to PyPI automatically.


### PR DESCRIPTION
This is so we can do hotfixes of existing releases without either perfecting or reverting the stuff on main.