### PR TITLE
Fix racey hang while unwinding wrap_py_function

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,10 @@
 # History
 
+## 0.12.3 (2024-05-25)
+
+- Fix potential hang if JavaScript calls a function produced by `wrap_py_function` while
+    we're tearing it down.
+
 ## 0.12.2 (2024-05-20)
 
 - Add optional context manager and `.close()` semantics to Python `MiniRacer` class.

--- a/src/py_mini_racer/__about__.py
+++ b/src/py_mini_racer/__about__.py
@@ -1,3 +1,3 @@
 __author__ = "bpcreech"
 __email__ = "mini-racer@bpcreech.com"
-__version__ = "0.12.2"
+__version__ = "0.12.3"

--- a/src/py_mini_racer/_objects.py
+++ b/src/py_mini_racer/_objects.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from asyncio import Future
+from asyncio import get_running_loop
 from contextlib import ExitStack
 from operator import index as op_index
 from typing import (
@@ -27,6 +27,8 @@ from py_mini_racer._types import (
 )
 
 if TYPE_CHECKING:
+    from asyncio import Future
+
     from py_mini_racer._abstract_context import AbstractContext, AbstractValueHandle
     from py_mini_racer._numeric import Numeric
 
@@ -212,8 +214,8 @@ class JSPromise(JSObjectImpl):
         return self._do_await().__await__()
 
     async def _do_await(self) -> PythonJSConvertedTypes:
-        future: Future[PythonJSConvertedTypes] = Future()
-        loop = future.get_loop()
+        loop = get_running_loop()
+        future: Future[PythonJSConvertedTypes] = loop.create_future()
 
         def future_caller(value: Any) -> None:
             loop.call_soon_threadsafe(future.set_result, value)

--- a/tests/test_py_js_function.py
+++ b/tests/test_py_js_function.py
@@ -7,6 +7,7 @@ from time import time
 
 import pytest
 from py_mini_racer import (
+    JSPromise,
     JSPromiseError,
     MiniRacer,
 )
@@ -112,5 +113,43 @@ def test_slow(gc_check):
     # Just verify it didn't take 100 seconds (i.e., that things didn't execute
     # sequentially):
     assert time() - start < 10
+
+    gc_check.check(mr)
+
+
+def test_call_on_exit(gc_check):
+    """Checks that calls from JS made while we're trying to tear down the wrapped
+    function are ignored and don't break anything."""
+
+    mr = MiniRacer()
+
+    data = []
+
+    async def append(*args):
+        data.append(args)
+        return "foobar"
+
+    async def run():
+        async with mr.wrap_py_function(append) as jsfunc:
+            # "Install" our JS function on the global "this" object:
+            mr.eval("x => this.func = x")(jsfunc)
+
+            # Note: we don't await the promise, meaning we just start a call and never
+            # finish it:
+            assert isinstance(mr.eval("this.func(42)"), JSPromise)
+
+            # Generally (subject to race conditions) at this point the
+            # callback initiated by the above this.func(42) will be half-received:
+            # _Context.wrap_py_function.on_called will have gotten the callback, and
+            # will have told asyncio to deal with it on the loop thread. We will
+            # generally *not* have yet processed the call.
+            # After this line, we start tearing down the mr.wrap_py_function context
+            # manager, which entails stopping the call processor.
+            # Let's make sure we don't fall over ourselves (it's fair to either process
+            # the last straggling calls, or ignore them, but make sure we don't hang).
+
+    for _ in range(100):
+        data[:] = []
+        asyncio_run(run())
 
     gc_check.check(mr)


### PR DESCRIPTION
Before this change, `wrap_py_function` could tear down the JS callback function and stop processing callbacks, but then receive straggling callbacks that were still being transported from the V8 thread to the asyncio event loop thread. It would then the queue-accounting logic would wait on those last straggling callbacks and never finish them, since it had already torn down the processing task.

Now we may still create tasks for straggling callbacks, but then we'll consistently drop those tasks if we've already stopped processing pending items.

This also gets rid of the use of `asyncio.Queue` which I realized wasn't making anything easier. (I want it to be a golang channel, but it isn't!)